### PR TITLE
Remove async wrapper on structlog and awaits on log functions

### DIFF
--- a/stack/app/api/v1/assistants.py
+++ b/stack/app/api/v1/assistants.py
@@ -44,7 +44,7 @@ async def create_assistant(
         assistant = await assistant_repository.create_assistant(data=data.model_dump())
         return assistant
     except Exception as e:
-        await logger.exception(f"Error creating assistant: {str(e)}")
+        logger.exception(f"Error creating assistant: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while creating the assistant.",
@@ -159,7 +159,7 @@ async def create_assistant_file(
         # config = {"configurable": {"assistant_id": str(assistant_id), "file_id": str(data.file_id)}}
         # ids = ingest_runnable.batch([file_content_io], config)
         # if not ids:
-        #     await logger.exception(f"Error ingesting file: {data.file_id}")
+        #     logger.exception(f"Error ingesting file: {data.file_id}")
         #     raise HTTPException(status_code=500, detail="An error occurred while ingesting the file.")
 
         file_model = await file_repository.retrieve_file(data.file_id)
@@ -184,10 +184,10 @@ async def create_assistant_file(
         return response_data
 
     except HTTPException as e:
-        await logger.exception(f"Error creating assistant file: {str(e)}")
+        logger.exception(f"Error creating assistant file: {str(e)}")
         raise e
     except Exception as e:
-        await logger.exception(f"Error adding file to assistant: {str(e)}")
+        logger.exception(f"Error adding file to assistant: {str(e)}")
         raise HTTPException(
             status_code=500,
             detail="An error occurred while adding the file to the assistant.",
@@ -212,14 +212,14 @@ async def delete_assistant_file(
         service = get_vector_service()
         # delete the associated vector embeddings
         deleted_chunks = await service.delete(str(file_id), str(assistant_id))
-        await logger.info(f"Deleted {deleted_chunks} chunks")
+        logger.info(f"Deleted {deleted_chunks} chunks")
         # Delete the file from the assistant's file_ids
         assistant = await assistant_repository.remove_file_reference_from_assistant(
             assistant_id, str(file_id)
         )
         return assistant
     except Exception as e:
-        await logger.exception(f"Error deleting assistant file: {str(e)}")
+        logger.exception(f"Error deleting assistant file: {str(e)}")
         raise HTTPException(
             status_code=500,
             detail="An error occurred while deleting the file from the assistant.",
@@ -254,7 +254,7 @@ async def retrieve_assistant_files(
         )
         return files
     except Exception as e:
-        await logger.exception(f"Error retrieving files for assistant: {str(e)}")
+        logger.exception(f"Error retrieving files for assistant: {str(e)}")
         raise HTTPException(
             status_code=500,
             detail="An error occurred while retrieving the files for the assistant.",

--- a/stack/app/api/v1/files.py
+++ b/stack/app/api/v1/files.py
@@ -179,9 +179,9 @@ async def delete_file(
             assistants = await assistant_repository.remove_all_file_references(file_id)
             num_of_assistants = len(assistants)
             if num_of_assistants > 0:
-                await logger.info(f"Deleted file from {num_of_assistants} assistants")
+                logger.info(f"Deleted file from {num_of_assistants} assistants")
             else:
-                await logger.info(f"Deleted file from 0 assistants")
+                logger.info(f"Deleted file from 0 assistants")
 
         # delete the file from the filesystem
         ext = guess_file_extension(file.mime_type)

--- a/stack/app/api/v1/rag.py
+++ b/stack/app/api/v1/rag.py
@@ -69,7 +69,7 @@ async def ingest(
         # TODO: return stats from ingestion
         return {"success": True}
     except Exception as e:
-        await logger.exception(f"Error ingesting files: {str(e)}")
+        logger.exception(f"Error ingesting files: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while ingesting the files.",
@@ -110,12 +110,12 @@ async def query(api_key: ApiKey, payload: QueryRequestPayload):
         )
         return response_data
     except HTTPException as e:
-        await logger.exception(
+        logger.exception(
             f"Error querying vector database: {str(e)}", exc_info=True
         )
         raise e
     except Exception as e:
-        await logger.exception(
+        logger.exception(
             f"Error querying vector database: {str(e)}", exc_info=True
         )
         raise HTTPException(status_code=500, detail=str(e))

--- a/stack/app/api/v1/runs.py
+++ b/stack/app/api/v1/runs.py
@@ -71,7 +71,7 @@ async def _run_input_and_config(
     )
 
     if not assistant:
-        await logger.exception("Invalid Assistant ID Provided", exc_info=False)
+        logger.exception("Invalid Assistant ID Provided", exc_info=False)
         raise ValueError(f"Invalid Assistant ID Provided")
 
     config: RunnableConfig = {

--- a/stack/app/core/struct_logger.py
+++ b/stack/app/core/struct_logger.py
@@ -79,13 +79,13 @@ def init_structlogger(settings: Settings):
         structlog.contextvars.merge_contextvars,
         structlog.processors.CallsiteParameterAdder(
             {
-                structlog.processors.CallsiteParameter.PATHNAME,
+                # structlog.processors.CallsiteParameter.PATHNAME,
                 structlog.processors.CallsiteParameter.FILENAME,
                 structlog.processors.CallsiteParameter.MODULE,
                 structlog.processors.CallsiteParameter.FUNC_NAME,
                 structlog.processors.CallsiteParameter.THREAD,
-                structlog.processors.CallsiteParameter.THREAD_NAME,
-                structlog.processors.CallsiteParameter.PROCESS,
+                # structlog.processors.CallsiteParameter.THREAD_NAME,
+                # structlog.processors.CallsiteParameter.PROCESS,
                 structlog.processors.CallsiteParameter.PROCESS_NAME,
             }
         ),
@@ -94,22 +94,22 @@ def init_structlogger(settings: Settings):
         drop_color_message_key,
     ]
 
-    structlog.configure(
-        processors=shared_processors
-        + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        # call log with await syntax in thread pool executor
-        wrapper_class=structlog.stdlib.AsyncBoundLogger,
-        cache_logger_on_first_use=True,
-    )
-
-    # Use this configuration instead when refactoring the logs to remove async requirement
     # structlog.configure(
     #     processors=shared_processors
     #     + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
     #     logger_factory=structlog.stdlib.LoggerFactory(),
+    #     # call log with await syntax in thread pool executor
+    #     wrapper_class=structlog.stdlib.AsyncBoundLogger,
     #     cache_logger_on_first_use=True,
     # )
+
+    # Use this configuration instead when refactoring the logs to remove async requirement
+    structlog.configure(
+        processors=shared_processors
+        + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
 
     log_renderer: structlog.types.Processor
 

--- a/stack/app/middlewares/system_logger.py
+++ b/stack/app/middlewares/system_logger.py
@@ -52,7 +52,7 @@ class SystemLoggerMiddleware(BaseHTTPMiddleware):
         try:
             response = await call_next(request)
         except Exception:
-            await structlog.stdlib.get_logger("api.error").exception(
+            structlog.stdlib.get_logger("api.error").exception(
                 "Uncaught exception"
             )
             raise
@@ -67,7 +67,7 @@ class SystemLoggerMiddleware(BaseHTTPMiddleware):
             http_version = request.scope["http_version"]
             # Recreate the Uvicorn access log format, but add all parameters as structured information
             access_logger = structlog.stdlib.get_logger("api.access")
-            await access_logger.info(
+            access_logger.info(
                 f"""{client_host}:{client_port} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
                 http={
                     "url": str(request.url),

--- a/stack/app/rag/query.py
+++ b/stack/app/rag/query.py
@@ -40,7 +40,7 @@ async def get_documents(
 ) -> list[BaseDocumentChunk]:
     chunks = await vector_service.query(input=payload.input, top_k=5)
     if not len(chunks):
-        await logger.info(f"No documents found for query: {payload.input}")
+        logger.info(f"No documents found for query: {payload.input}")
         return []
 
     if not payload.enable_rerank:

--- a/stack/app/rag/splitter.py
+++ b/stack/app/rag/splitter.py
@@ -177,7 +177,7 @@ class UnstructuredSemanticSplitter:
                     metadata.pop("text_as_html", None)
                     for table in splitted_tables:
                         if not table:
-                            await logger.warning("Empty table encountered")
+                            logger.warning("Empty table encountered")
                             continue
                         self._append_chunks(
                             chunks_with_title,

--- a/stack/app/repositories/assistant.py
+++ b/stack/app/repositories/assistant.py
@@ -40,7 +40,7 @@ class AssistantRepository(BaseRepository):
             return assistant
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to create assistant due to a database error.", exc_info=True
             )
             raise HTTPException(
@@ -71,7 +71,7 @@ class AssistantRepository(BaseRepository):
             records = await self.retrieve_all(model=Assistant, filters=filters)
             return records
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve assistants due to a database error.", exc_info=True
             )
             raise HTTPException(
@@ -85,7 +85,7 @@ class AssistantRepository(BaseRepository):
             record = await self.retrieve_one(query=query, object_id=assistant_id)
             return record
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve assistant due to a database error.", exc_info=True
             )
             raise HTTPException(status_code=500, detail="Failed to retrieve assistant.")
@@ -102,7 +102,7 @@ class AssistantRepository(BaseRepository):
             return assistant
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to update assistant due to a database error. {e}",
                 exc_info=True,
             )
@@ -116,7 +116,7 @@ class AssistantRepository(BaseRepository):
             return assistant
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to delete assistant due to a database error: ", exc_info=True
             )
             raise HTTPException(status_code=400, detail="Failed to delete assistant.")
@@ -138,7 +138,7 @@ class AssistantRepository(BaseRepository):
                 raise HTTPException(status_code=404, detail="Assistant not found")
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to add file to assistant due to a database error.",
                 exc_info=True,
             )
@@ -166,7 +166,7 @@ class AssistantRepository(BaseRepository):
                 raise HTTPException(status_code=404, detail="Assistant not found")
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to remove file from assistant due to a database error.",
                 exc_info=True,
             )
@@ -199,7 +199,7 @@ class AssistantRepository(BaseRepository):
             return updated_assistants
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to remove file references from assistants due to a database error.",
                 exc_info=True,
             )

--- a/stack/app/repositories/file.py
+++ b/stack/app/repositories/file.py
@@ -52,7 +52,7 @@ class FileRepository(BaseRepository):
             return update_file
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to create file due to a database error.",
                 exc_info=True,
                 file_data=data,
@@ -89,7 +89,7 @@ class FileRepository(BaseRepository):
             records = await self.retrieve_all(model=File, filters=filters)
             return records
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve files due to a database error.",
                 exc_info=True,
                 user_id=user_id,
@@ -104,7 +104,7 @@ class FileRepository(BaseRepository):
             record = await self.retrieve_one(query=query, object_id=file_id)
             return record
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve file due to a database error.",
                 exc_info=True,
                 file_id=file_id,
@@ -125,12 +125,12 @@ class FileRepository(BaseRepository):
             return file
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to delete file due to a database error: ", exc_info=True
             )
             raise HTTPException(status_code=400, detail="Failed to delete file.")
         except FileNotFoundError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to delete file content from local file system: ",
                 exc_info=True,
                 file_id=file_id,
@@ -144,10 +144,10 @@ class FileRepository(BaseRepository):
         try:
             file = await self.retrieve_file(file_id)
             if not file:
-                await logger.exception(f"File: {file_id} not found.")
+                logger.exception(f"File: {file_id} not found.")
                 raise HTTPException(status_code=404, detail="File not found.")
             file_path = file.source
-            await logger.info(
+            logger.info(
                 f"Reading content for file {file_id} from local file system. File path: {file_path}"
             )
             with open(file_path, "rb") as f:
@@ -155,7 +155,7 @@ class FileRepository(BaseRepository):
             return file_content
 
         except FileNotFoundError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve file content from local file system.",
                 exc_info=True,
                 file_id=file_id,
@@ -163,7 +163,7 @@ class FileRepository(BaseRepository):
             raise HTTPException(status_code=404, detail="File content not found.")
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to delete file due to a database error: ", exc_info=True
             )
             raise HTTPException(status_code=400, detail="Failed to delete file.")
@@ -208,7 +208,7 @@ class FileRepository(BaseRepository):
             records = result.scalars().all()
             return records
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve files due to a database error.", exc_info=True
             )
             raise HTTPException(status_code=500, detail="Failed to retrieve files.")

--- a/stack/app/repositories/message.py
+++ b/stack/app/repositories/message.py
@@ -52,7 +52,7 @@ class MessageRepository(BaseRepository):
             return message
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to create message due to a database error",
                 exc_info=True,
                 message_data=data,
@@ -85,7 +85,7 @@ class MessageRepository(BaseRepository):
             records = result.fetchall()
             return records
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 "Failed to retrieve messages by thread_id due to a database error",
                 exc_info=True,
                 thread_id=thread_id,
@@ -104,7 +104,7 @@ class MessageRepository(BaseRepository):
             return message
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to update message due to a database error",
                 exc_info=True,
                 message_id=message_id,
@@ -120,7 +120,7 @@ class MessageRepository(BaseRepository):
             return message
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to delete message due to a database error",
                 exc_info=True,
                 message_id=message_id,

--- a/stack/app/repositories/thread.py
+++ b/stack/app/repositories/thread.py
@@ -41,7 +41,7 @@ class ThreadRepository(BaseRepository):
             return thread
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to create thread due to a database error",
                 exc_info=True,
                 thread_data=data,
@@ -73,7 +73,7 @@ class ThreadRepository(BaseRepository):
             records = await self.retrieve_all(model=Thread, filters=filters)
             return records
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 "Failed to retrieve threads due to a database error", exc_info=True
             )
             raise HTTPException(status_code=500, detail="Failed to retrieve threads.")
@@ -85,7 +85,7 @@ class ThreadRepository(BaseRepository):
             record = await self.retrieve_one(query=query, object_id=thread_id)
             return record
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 "Failed to retrieve thread due to a database error",
                 exc_info=True,
                 thread_id=thread_id,
@@ -100,7 +100,7 @@ class ThreadRepository(BaseRepository):
             record = result.fetchone()
             return record
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 "Failed to retrieve thread by thread_id due to a database error",
                 exc_info=True,
                 thread_id=thread_id,
@@ -117,7 +117,7 @@ class ThreadRepository(BaseRepository):
             return thread
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to update thread due to a database error",
                 exc_info=True,
                 thread_id=thread_id,
@@ -133,7 +133,7 @@ class ThreadRepository(BaseRepository):
             return thread
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to delete thread due to a database error",
                 exc_info=True,
                 thread_id=thread_id,
@@ -148,7 +148,7 @@ class ThreadRepository(BaseRepository):
             records = result.fetchall()
             return records
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 "Failed to retrieve threads for user_id due to a database error",
                 exc_info=True,
                 user_id=user_id,

--- a/stack/app/repositories/user.py
+++ b/stack/app/repositories/user.py
@@ -64,7 +64,7 @@ class UserRepository(BaseRepository):
             return user
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 f"Failed to create user due to a database error: {str(e)}",
                 exc_info=True,
                 user_data=data.json(),
@@ -96,7 +96,7 @@ class UserRepository(BaseRepository):
             records = await self.retrieve_all(model=User, filters=filters)
             return records
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve users due to a database error: {str(e)}",
                 exc_info=True,
             )
@@ -109,7 +109,7 @@ class UserRepository(BaseRepository):
             record = await self.retrieve_one(query=query, object_id=object_id)
             return record
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 f"Failed to retrieve user due to a database error: {str(e)}",
                 exc_info=True,
                 object_id=object_id,
@@ -124,7 +124,7 @@ class UserRepository(BaseRepository):
             record = result.fetchone()
             return record
         except SQLAlchemyError as e:
-            await logger.exception(
+            logger.exception(
                 "Failed to retrieve user by user_id due to a database error",
                 exc_info=True,
                 object_id=user_id,
@@ -142,7 +142,7 @@ class UserRepository(BaseRepository):
             return user
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to update user due to a database error",
                 exc_info=True,
                 object_id=object_id,
@@ -161,7 +161,7 @@ class UserRepository(BaseRepository):
             return updated_user
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to update user by user_id due to a database error",
                 exc_info=True,
                 object_id=user_id,
@@ -179,7 +179,7 @@ class UserRepository(BaseRepository):
             return user
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to delete user due to a database error",
                 exc_info=True,
                 object_id=object_id,
@@ -196,7 +196,7 @@ class UserRepository(BaseRepository):
             return user
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
-            await logger.exception(
+            logger.exception(
                 "Failed to delete user by user_id due to a database error",
                 exc_info=True,
                 object_id=user_id,

--- a/stack/app/vectordbs/qdrant.py
+++ b/stack/app/vectordbs/qdrant.py
@@ -155,7 +155,7 @@ class QdrantService(BaseVectorDatabase):
             count_filter=common_filter,
             exact=True,
         )
-        await logger.info(f"Preparing to delete {deleted_chunks.count} chunks")
+        logger.info(f"Preparing to delete {deleted_chunks.count} chunks")
 
         self.client.delete(
             collection_name=self.index_name,


### PR DESCRIPTION
Logging methods were having to be awaited because there was an explicit async wrapper in the structlog config forcing all methods to be async. This fixes that, allowing for only the methods that are prefixed with "a" to run async. 