### PR TITLE
refactor (PersonaFlow-116): Remove lib from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Issue
I realized that `lib` contents in the UI were added to `gitignore` file and not being pushed to main. This folder contains `utils.ts` which holds config for the tailwind `cn` functionality to combine tailwind classes.