### PR TITLE
fix issue with assistant selector

### DIFF
--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -47,82 +47,90 @@ export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
         onSubmit={form.handleSubmit(onSubmit)}
         className="overflow-y-scroll hide-scrollbar"
       >
-        <div className="flex flex-col gap-6">
-          <div className="flex gap-6">
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <Input
-                      placeholder="Assistant Name"
-                      type="text"
-                      {...field}
-                      className="w-[400px]"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+        <div className="rounded-md bg-gray-50 p-4 md:p-6">
+          <div className="flex flex-col gap-6">
+            <div className="flex gap-6">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Input
+                        placeholder="Assistant Name"
+                        type="text"
+                        {...field}
+                        className="w-[400px]"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <PublicSwitch form={form} />
+            </div>
+            <FormSelect
+              form={form}
+              options={
+                (config?.definitions.Bot_Type as TSchemaField).enum ?? []
+              }
+              formName="config.configurable.type"
+              title="Select architecture"
+              placeholder="Select architecture"
             />
-            <PublicSwitch form={form} />
-          </div>
-          <FormSelect
-            form={form}
-            options={(config?.definitions.Bot_Type as TSchemaField).enum ?? []}
-            formName="config.configurable.type"
-            title="Select architecture"
-            placeholder="Select architecture"
-          />
-          {architectureType && (
-            <>
-              {architectureType === "agent" ? (
-                <FormSelect
-                form={form}
-                options={(config?.definitions.AgentType as TSchemaField).enum ?? []}
-                formName="config.configurable.agent_type"
-                title="Agent type"
-                placeholder="Select agent type"
-              />
-              ) : (
-                <FormSelect
-                form={form}
-                options={(config?.definitions.LLMType as TSchemaField).enum ?? []}
-                formName="config.configurable.llm_type"
-                title="LLM type"
-                placeholder="Select LLM type"
-              />
-              )}
-              <SystemPrompt form={form} />
-              {architectureType !== "chatbot" && (
-                <>
-                  <SelectCapabilities form={form} />
-                  <RetrievalInstructions form={form} />
-                  <div className="flex gap-6 flex-col">
-                    <SelectFiles form={form} />
-                    <div className="w-50">
-                      <FilesDialog form={form} />
+            {architectureType && (
+              <>
+                {architectureType === "agent" ? (
+                  <FormSelect
+                    form={form}
+                    options={
+                      (config?.definitions.AgentType as TSchemaField).enum ?? []
+                    }
+                    formName="config.configurable.agent_type"
+                    title="Agent type"
+                    placeholder="Select agent type"
+                  />
+                ) : (
+                  <FormSelect
+                    form={form}
+                    options={
+                      (config?.definitions.LLMType as TSchemaField).enum ?? []
+                    }
+                    formName="config.configurable.llm_type"
+                    title="LLM type"
+                    placeholder="Select LLM type"
+                  />
+                )}
+                <SystemPrompt form={form} />
+                {architectureType !== "chatbot" && (
+                  <>
+                    <SelectCapabilities form={form} />
+                    <RetrievalInstructions form={form} />
+                    <div className="flex gap-6 flex-col">
+                      <SelectFiles form={form} />
+                      <div className="w-50">
+                        <FilesDialog form={form} />
+                      </div>
                     </div>
-                  </div>
-                  {architectureType !== "chat_retrieval" && (
-                    <SelectTools form={form} />
-                  )}
-                  <SelectOptions form={form} />
-                  {architectureType !== "chat_retrieval" && (
-                    <SelectActions form={form} />
-                  )}
-                </>
-              )}
-              <Button
-                type="submit"
-                className="w-1/4 self-center"
-                disabled={!isDirty}
-              >
-                Save
-              </Button>
-            </>
-          )}
+                    {architectureType !== "chat_retrieval" && (
+                      <SelectTools form={form} />
+                    )}
+                    <SelectOptions form={form} />
+                    {architectureType !== "chat_retrieval" && (
+                      <SelectActions form={form} />
+                    )}
+                  </>
+                )}
+                <Button
+                  type="submit"
+                  className="w-1/4 self-center"
+                  disabled={!isDirty}
+                >
+                  Save
+                </Button>
+              </>
+            )}
+          </div>
         </div>
       </form>
     </Form>

--- a/ui/src/components/features/build-panel/components/assistant-selector.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-selector.tsx
@@ -9,53 +9,27 @@ import {
 } from "@/components/ui/select";
 import Spinner from "@/components/ui/spinner";
 import { useAssistants } from "@/data-provider/query-service";
-import { TAssistant } from "@/data-provider/types";
 import { useSlugRoutes } from "@/hooks/useSlugParams";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 
 export function AssistantSelector() {
-  const [selectedAssistant, setSelectedAssistant] = useState<TAssistant>();
-
-  const {assistantId} = useSlugRoutes();
+  const { assistantId } = useSlugRoutes();
   const { data: assistantsData, isLoading } = useAssistants();
   const router = useRouter();
 
-  useEffect(() => {
-    if (isLoading) return;
-
-    if (!selectedAssistant || assistantId !== selectedAssistant?.id) {
-      updateSelectedAssistant(assistantId as string)
-    }
-  },[assistantId, assistantsData])
+  if (isLoading || !assistantsData) return <Spinner />;
 
   const handleValueChange = (selectedAssistantId: string) => {
-    router.push(`/a/${selectedAssistantId}`)
-
-    const _selectedAssistant = assistantsData?.find(
-      (assistant) => assistant.id === selectedAssistantId,
-    );
-
-    if (_selectedAssistant) {
-      setSelectedAssistant(_selectedAssistant);
-    }
+    router.push(`/a/${selectedAssistantId}`);
   };
-
-  const updateSelectedAssistant = (selectedId: string) => {
-    const _selectedAssistant = assistantsData?.find(
-      (assistant) => assistant.id === selectedId,
-    );
-
-    setSelectedAssistant(_selectedAssistant);
-  }
-
-  if (isLoading || !assistantsData) return <Spinner />;
+  const selectedAssistant = assistantsData.find(
+    (assistant) => assistant.id === assistantId,
+  );
 
   return (
     <Select
       onValueChange={handleValueChange}
-      value={selectedAssistant?.id}
-      defaultValue={selectedAssistant?.name}
+      value={selectedAssistant?.id ?? ""}
     >
       <SelectTrigger className="w-[180px] border-accent">
         <SelectValue placeholder="Select assistant.." />

--- a/ui/src/components/features/build-panel/components/build-panel.tsx
+++ b/ui/src/components/features/build-panel/components/build-panel.tsx
@@ -12,7 +12,10 @@ export default function BuildPanel() {
   };
 
   return (
-    <div className="flex items-center bg-slate-100 text-black rounded">
+    <div
+      className="flex items-center bg-slate-100 text-black rounded"
+      data-testid="build-panel"
+    >
       <div className=" p-1">
         {isOpen ? (
           <ChevronRight

--- a/ui/src/components/features/build-panel/components/create-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/create-assistant.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import {
-  useCreateAssistant,
-} from "@/data-provider/query-service";
+import { useCreateAssistant } from "@/data-provider/query-service";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -36,7 +34,7 @@ const RetrievalType = "retrieval";
 export function CreateAssistant() {
   const createAssistant = useCreateAssistant();
 
-  const router = useRouter()
+  const router = useRouter();
 
   const { toast } = useToast();
 
@@ -109,5 +107,10 @@ export function CreateAssistant() {
     });
   }
 
-  return <AssistantForm form={form} onSubmit={onSubmit} />;
+  return (
+    <>
+      <h1 className="text-2xl font-bold">Create Assistant</h1>
+      <AssistantForm form={form} onSubmit={onSubmit} />
+    </>
+  );
 }

--- a/ui/src/components/features/build-panel/components/edit-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/edit-assistant.tsx
@@ -19,11 +19,12 @@ import Spinner from "@/components/ui/spinner";
 const RetrievalType = "retrieval";
 
 export function EditAssistant() {
-  const {assistantId} = useSlugRoutes();
+  const { assistantId } = useSlugRoutes();
 
-  const {data: selectedAssistant, isLoading: isLoadingAssistant} = useAssistant(assistantId as string, {
-    enabled: !!assistantId
-  })
+  const { data: selectedAssistant, isLoading: isLoadingAssistant } =
+    useAssistant(assistantId as string, {
+      enabled: !!assistantId,
+    });
 
   const updateAssistant = useUpdateAssistant(selectedAssistant?.id as string);
 
@@ -97,13 +98,18 @@ export function EditAssistant() {
       onError: () => {
         toast({
           variant: "destructive",
-          title: "Failed to update assistant."
-        })
-      }
+          title: "Failed to update assistant.",
+        });
+      },
     });
   }
 
-  if (isLoadingAssistant) return <Spinner />
+  if (isLoadingAssistant) return <Spinner />;
 
-  return <AssistantForm form={form} onSubmit={onSubmit} />;
+  return (
+    <>
+      <h1 className="text-2xl font-bold">Edit Assistant</h1>
+      <AssistantForm form={form} onSubmit={onSubmit} />
+    </>
+  );
 }

--- a/ui/src/components/features/chat-panel/chat-panel.tsx
+++ b/ui/src/components/features/chat-panel/chat-panel.tsx
@@ -52,7 +52,7 @@ export default function ChatPanel() {
   };
 
   return (
-    <div className="h-full w-full gap-4 flex flex-col">
+    <div className="h-full w-full gap-4 flex flex-col" data-testid="chat-panel">
       <div className="h-full flex flex-col rounded">
         {threadId || isNewThread ? (
           <MessagesContainer


### PR DESCRIPTION
Fixes issue with Assistant Selector where on assistant selection and clicking on Create Assistant the selector would still display an old value when the current assistant is undefined.
Simplifies assistant selector code a bit.
Adds headers to Create and Edit assistant forms.
Adds gray background for forms - this could be deleted - I just played with it.

To test:

Choose assistant
Make sure the assistant is chosen in the Select and reflected in url (a/...)
Click on Create Assistant
Make sure the assistant is reset in Select and URL 
