### PR TITLE
fix Assistant Builder form Select values (#201)

### DIFF
--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -67,6 +67,8 @@ export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
                   </FormItem>
                 )}
               />
+            </div>
+            <div className="flex gap-6">
               <PublicSwitch form={form} />
             </div>
             <FormSelect

--- a/ui/src/components/features/build-panel/components/edit-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/edit-assistant.tsx
@@ -20,13 +20,30 @@ const RetrievalType = "retrieval";
 
 export function EditAssistant() {
   const { assistantId } = useSlugRoutes();
-
   const { data: selectedAssistant, isLoading: isLoadingAssistant } =
     useAssistant(assistantId as string, {
       enabled: !!assistantId,
     });
 
-  const updateAssistant = useUpdateAssistant(selectedAssistant?.id as string);
+  return isLoadingAssistant ? (
+    <Spinner />
+  ) : (
+    <>
+      {selectedAssistant ? (
+        <EditAssistantForm selectedAssistant={selectedAssistant} />
+      ) : (
+        <div>Assistant not found</div>
+      )}
+    </>
+  );
+}
+
+function EditAssistantForm({
+  selectedAssistant,
+}: {
+  selectedAssistant: TAssistant;
+}) {
+  const updateAssistant = useUpdateAssistant(selectedAssistant.id as string);
 
   const form = useForm<TAssistant>({
     resolver: zodResolver(formSchema),
@@ -103,8 +120,6 @@ export function EditAssistant() {
       },
     });
   }
-
-  if (isLoadingAssistant) return <Spinner />;
 
   return (
     <>

--- a/ui/src/components/features/build-panel/components/form-select.tsx
+++ b/ui/src/components/features/build-panel/components/form-select.tsx
@@ -23,7 +23,13 @@ type TFormSelectProps = {
   placeholder: string;
 };
 
-export function FormSelect({ form, title ,options, formName, placeholder }: TFormSelectProps) {
+export function FormSelect({
+  form,
+  title,
+  options,
+  formName,
+  placeholder,
+}: TFormSelectProps) {
   return (
     <FormField
       control={form.control}
@@ -32,7 +38,7 @@ export function FormSelect({ form, title ,options, formName, placeholder }: TFor
         <FormItem className="flex flex-col">
           <FormLabel>{title}</FormLabel>
           <FormControl>
-            <Select onValueChange={field.onChange} defaultValue={field.value}>
+            <Select onValueChange={field.onChange} value={field.value}>
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder={placeholder} />
               </SelectTrigger>

--- a/ui/src/components/features/navbar/components/navbar.tsx
+++ b/ui/src/components/features/navbar/components/navbar.tsx
@@ -30,11 +30,6 @@ export default function Navbar() {
     }
   }, [assistantId, threadsData]);
 
-  useEffect(() => {
-    console.log(isFetching);
-    console.log(threadsData);
-  }, [threadsData, isFetching]);
-
   const filterThreads = (groupedThreads: TGroupedThreads) =>
     Object.entries(groupedThreads).reduce(
       (newGroupedThreads, [grouping, threads]) => {


### PR DESCRIPTION
Fixes Selectors in the Assistant Builder.
It should load proper values for Architecture, Agent Type, and LLM Type.

Closes #201 