### PR TITLE
bug (PersonaFlow-203): Refetch assistant form on assistant update

### DIFF
--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -108,11 +108,11 @@ export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
                   <>
                     <SelectCapabilities form={form} />
                     <RetrievalInstructions form={form} />
-                    <div className="flex gap-6 flex-col">
+                    <div className="flex flex-col">
+                      {/* <div className="w-full flex justify-between mb-4"> */}
+                        <FilesDialog classNames="mb-4" form={form} />
+                      {/* </div> */}
                       <SelectFiles form={form} />
-                      <div className="w-50">
-                        <FilesDialog form={form} />
-                      </div>
                     </div>
                     {architectureType !== "chat_retrieval" && (
                       <SelectTools form={form} />

--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -109,9 +109,7 @@ export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
                     <SelectCapabilities form={form} />
                     <RetrievalInstructions form={form} />
                     <div className="flex flex-col">
-                      {/* <div className="w-full flex justify-between mb-4"> */}
-                        <FilesDialog classNames="mb-4" form={form} />
-                      {/* </div> */}
+                      <FilesDialog classNames="mb-4" form={form} />
                       <SelectFiles form={form} />
                     </div>
                     {architectureType !== "chat_retrieval" && (

--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -23,6 +23,7 @@ import { useRunnableConfigSchema } from "@/data-provider/query-service";
 import type { TSchemaField } from "@/data-provider/types";
 import Spinner from "@/components/ui/spinner";
 import { FormSelect } from "./form-select";
+import { useEffect } from "react";
 
 type TAssistantFormProps = {
   form: UseFormReturn<any>;
@@ -32,6 +33,10 @@ type TAssistantFormProps = {
 export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
   const { type: architectureType } = form.getValues().config.configurable;
   const { data: config, isLoading, isError } = useRunnableConfigSchema();
+
+  useEffect(() => {
+    console.log(config)
+  },[config])
 
   const {
     formState: { isDirty },

--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -124,6 +124,7 @@ export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
                   </>
                 )}
                 <Button
+                  variant="outline"
                   type="submit"
                   className="w-1/4 self-center"
                   disabled={!isDirty}

--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -23,7 +23,6 @@ import { useRunnableConfigSchema } from "@/data-provider/query-service";
 import type { TSchemaField } from "@/data-provider/types";
 import Spinner from "@/components/ui/spinner";
 import { FormSelect } from "./form-select";
-import { useEffect } from "react";
 
 type TAssistantFormProps = {
   form: UseFormReturn<any>;
@@ -33,10 +32,6 @@ type TAssistantFormProps = {
 export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
   const { type: architectureType } = form.getValues().config.configurable;
   const { data: config, isLoading, isError } = useRunnableConfigSchema();
-
-  useEffect(() => {
-    console.log(config)
-  },[config])
 
   const {
     formState: { isDirty },

--- a/ui/src/components/features/build-panel/components/create-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/create-assistant.tsx
@@ -11,6 +11,7 @@ import { formSchema } from "@/data-provider/types";
 import { useAvailableTools } from "@/hooks/useAvailableTools";
 import { useToast } from "@/components/ui/use-toast";
 import { useRouter } from "next/navigation";
+import { SquarePlus } from "lucide-react";
 
 const defaultValues = {
   public: false,
@@ -109,7 +110,10 @@ export function CreateAssistant() {
 
   return (
     <>
-      <h1 className="text-2xl font-bold">Create Assistant</h1>
+      <div className="flex gap-2 items-center">
+        <SquarePlus />
+        <h1 className="text-2xl">Create</h1>
+      </div>
       <AssistantForm form={form} onSubmit={onSubmit} />
     </>
   );

--- a/ui/src/components/features/build-panel/components/edit-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/edit-assistant.tsx
@@ -24,6 +24,11 @@ export function EditAssistant() {
     useAssistant(assistantId as string, {
       enabled: !!assistantId,
     });
+  
+  
+  useEffect(() => {
+    console.log(selectedAssistant)
+  },[selectedAssistant])
 
   return isLoadingAssistant ? (
     <Spinner />
@@ -62,6 +67,8 @@ function EditAssistantForm({
   );
 
   const { availableTools } = useAvailableTools();
+
+  useEffect(() => console.log(selectedAssistant),[selectedAssistant])
 
   useEffect(() => {
     if (selectedAssistant) {

--- a/ui/src/components/features/build-panel/components/edit-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/edit-assistant.tsx
@@ -25,11 +25,6 @@ export function EditAssistant() {
     useAssistant(assistantId as string, {
       enabled: !!assistantId,
     });
-  
-  
-  useEffect(() => {
-    console.log(selectedAssistant)
-  },[selectedAssistant])
 
   return isLoadingAssistant ? (
     <Spinner />

--- a/ui/src/components/features/build-panel/components/edit-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/edit-assistant.tsx
@@ -68,8 +68,6 @@ function EditAssistantForm({
 
   const { availableTools } = useAvailableTools();
 
-  useEffect(() => console.log(selectedAssistant),[selectedAssistant])
-
   useEffect(() => {
     if (selectedAssistant) {
       form.reset(selectedAssistant);

--- a/ui/src/components/features/build-panel/components/edit-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/edit-assistant.tsx
@@ -15,6 +15,7 @@ import { useAvailableTools } from "@/hooks/useAvailableTools";
 import { useToast } from "@/components/ui/use-toast";
 import { useSlugRoutes } from "@/hooks/useSlugParams";
 import Spinner from "@/components/ui/spinner";
+import { LucidePencil } from "lucide-react";
 
 const RetrievalType = "retrieval";
 
@@ -128,7 +129,10 @@ function EditAssistantForm({
 
   return (
     <>
-      <h1 className="text-2xl font-bold">Edit Assistant</h1>
+      <div className="flex gap-2 items-center">
+        <LucidePencil />
+        <h1 className="text-2xl">Edit</h1>
+      </div>
       <AssistantForm form={form} onSubmit={onSubmit} />
     </>
   );

--- a/ui/src/components/features/build-panel/components/files-dialog.tsx
+++ b/ui/src/components/features/build-panel/components/files-dialog.tsx
@@ -25,6 +25,7 @@ import {
   FormItem,
   FormLabel,
 } from "@/components/ui/form";
+import { useToast } from "@/components/ui/use-toast";
 
 type TFilesDialog = {
   form: UseFormReturn<any>;
@@ -43,6 +44,8 @@ export default function FilesDialog({ form }: TFilesDialog) {
   const uploadFile = useUploadFile();
 
   const { file_ids } = form.getValues();
+
+  const {toast} = useToast();
 
   const formattedAssistantFiles = files?.reduce((files, file) => {
     if (file_ids.includes(file.id)) {
@@ -76,6 +79,16 @@ export default function FilesDialog({ form }: TFilesDialog) {
       uploadFile.mutate(formData, {
         onSuccess: () => {
           setFileUpload(null);
+          toast({
+            variant: "default",
+            title: "New file saved.",
+          });
+        },
+        onError: () => {
+          toast({
+            variant: "destructive",
+            title: "Something went wrong while saving file.",
+          });
         },
       });
     }

--- a/ui/src/components/features/build-panel/components/files-dialog.tsx
+++ b/ui/src/components/features/build-panel/components/files-dialog.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { FileIcon } from "@radix-ui/react-icons";
 import {
   Dialog,
@@ -14,7 +14,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { UseFormReturn } from "react-hook-form";
-import { SquarePlus } from "lucide-react";
+import { Plus, SquarePlus } from "lucide-react";
 import MultiSelect from "@/components/ui/multiselect";
 import { useFiles, useUploadFile } from "@/data-provider/query-service";
 import Spinner from "@/components/ui/spinner";
@@ -26,9 +26,11 @@ import {
   FormLabel,
 } from "@/components/ui/form";
 import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/utils/utils";
 
 type TFilesDialog = {
   form: UseFormReturn<any>;
+  classNames: string;
 };
 
 type TOption = {
@@ -36,7 +38,7 @@ type TOption = {
   value: string;
 };
 
-export default function FilesDialog({ form }: TFilesDialog) {
+export default function FilesDialog({ form, classNames }: TFilesDialog) {
   const [fileUpload, setFileUpload] = useState<File | null>();
   const [values, setValues] = useState<TOption[]>([]);
   const { data: files, isLoading } = useFiles("assistants");
@@ -99,11 +101,11 @@ export default function FilesDialog({ form }: TFilesDialog) {
   return (
     <Dialog>
       <DialogTrigger
-        className="flex gap-2 border-2 rounded-md p-2 border-black"
+        className={cn(buttonVariants({ variant: "outline" }), "gap-2", classNames)}
         type="button"
       >
-        <SquarePlus />
-        Add Files
+        <Plus />
+        Manage Files
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/ui/src/components/features/build-panel/components/files-dialog.tsx
+++ b/ui/src/components/features/build-panel/components/files-dialog.tsx
@@ -143,6 +143,7 @@ export default function FilesDialog({ form }: TFilesDialog) {
               </CardContent>
               <CardFooter>
                 <Button
+                  variant="default"
                   disabled={!fileUpload}
                   size="lg"
                   type="button"

--- a/ui/src/components/features/build-panel/components/retrieval-description.tsx
+++ b/ui/src/components/features/build-panel/components/retrieval-description.tsx
@@ -17,7 +17,7 @@ export function RetrievalInstructions({ form }: TRetrievalInstructionsProps) {
         return (
           <FormItem className="flex flex-col gap-2">
             <FormLabel>Retrieval Instructions</FormLabel>
-            <Textarea {...field} />
+            <Textarea className="h-[125px]" {...field} />
           </FormItem>
         );
       }}

--- a/ui/src/components/features/build-panel/components/select-files.tsx
+++ b/ui/src/components/features/build-panel/components/select-files.tsx
@@ -57,7 +57,9 @@ export default function SelectFiles({ form }: TSelectFilesProps) {
                       className="rounded-full flex cursor-pointer text-xs gap-1 py-1 max-w-40"
                       onClick={() => remove(index)}
                     >
-                      <span className="truncate">{badgeValue.label}</span>
+                      <span className="truncate">
+                        <p>{badgeValue.label}</p>
+                      </span>
                       <div>
                         <CircleX size={16} />
                       </div>

--- a/ui/src/components/features/build-panel/components/select-files.tsx
+++ b/ui/src/components/features/build-panel/components/select-files.tsx
@@ -54,7 +54,7 @@ export default function SelectFiles({ form }: TSelectFilesProps) {
                   <FormControl>
                     <Badge
                       variant="outline"
-                      className="rounded-full flex cursor-pointer text-xs gap-1 w-1/2 py-1"
+                      className="rounded-full flex cursor-pointer text-xs gap-1 py-1 max-w-40"
                       onClick={() => remove(index)}
                     >
                       <span className="truncate">{badgeValue.label}</span>

--- a/ui/src/components/features/build-panel/components/select-files.tsx
+++ b/ui/src/components/features/build-panel/components/select-files.tsx
@@ -53,11 +53,14 @@ export default function SelectFiles({ form }: TSelectFilesProps) {
                 <FormItem>
                   <FormControl>
                     <Badge
-                      className="rounded-full flex cursor-pointer text-xs gap-2"
+                      variant="outline"
+                      className="rounded-full flex cursor-pointer text-xs gap-1 w-1/2 py-1"
                       onClick={() => remove(index)}
                     >
-                      <p>{badgeValue.label}</p>
-                      <CircleX className="w-4" />
+                      <span className="truncate">{badgeValue.label}</span>
+                      <div>
+                        <CircleX size={16} />
+                      </div>
                     </Badge>
                   </FormControl>
                 </FormItem>

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -9,12 +9,13 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80 hover:text-black hover:outline",
+          "border-transparent bg-primary text-primary-foreground shadow hover:opacity-80",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
+        outline:
+          "border-none bg-primary text-white shadow-sm transition-all duration-200 hover:opacity-80",
       },
     },
     defaultVariants: {

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-accent hover:text-accent-foreground hover:outline",
+          "bg-primary text-primary-foreground shadow hover:opacity-80 transition-all duration-200",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline:

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -26,6 +26,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             "flex h-10 w-full rounded-md border border-input bg-foreground-opacity-50 py-2 px-4 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
             startIcon ? "pl-8" : "",
             endIcon ? "pr-8" : "",
+            type === 'file' ? "cursor-pointer transition-all duration-200 hover:bg-accent" : "",
             className,
           )}
           ref={ref}

--- a/ui/src/data-provider/query-service.ts
+++ b/ui/src/data-provider/query-service.ts
@@ -298,7 +298,7 @@ export const useUpdateAssistant = (assistantId: string) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKeys.configSchema] });
       queryClient.invalidateQueries({ queryKey: [QueryKeys.assistants] });
-      queryClient.invalidateQueries({ queryKey: [assistantId] });
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.assistant, assistantId] });
     },
   });
 };

--- a/ui/src/data-provider/query-service.ts
+++ b/ui/src/data-provider/query-service.ts
@@ -296,6 +296,7 @@ export const useUpdateAssistant = (assistantId: string) => {
     mutationFn: async (payload: t.TAssistant): Promise<t.TAssistant> =>
       await dataService.updateAssistant(assistantId, payload),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.configSchema] });
       queryClient.invalidateQueries({ queryKey: [QueryKeys.assistants] });
       queryClient.invalidateQueries({ queryKey: [assistantId] });
     },


### PR DESCRIPTION
## Overview
When an assistant has been updated, we want to trigger a refetch of the assistant form, which should trigger the form to no longer be considered "dirty".

Additionally, there were some extra style updates such as updating the default button variant, adding some minor tweaks to the Files Dialog, and updating the file selector styles in the assistant builder.