### PR TITLE
Embedding Service refactor, JSON and CSV support (#34), fix Ollama embeddings

### DIFF
--- a/stack/app/api/v1/files.py
+++ b/stack/app/api/v1/files.py
@@ -64,13 +64,14 @@ async def upload_file(
     try:
         if not file or not file.filename:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="File is required and must have a filename."
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="File is required and must have a filename.",
             )
         user_id = get_header_user_id(request)
 
         file_content = await file.read()
         original_filename = file.filename
-        
+
         mime_type = guess_mime_type(original_filename, file_content)
         if not is_mime_type_supported(mime_type):
             raise HTTPException(
@@ -103,7 +104,8 @@ async def upload_file(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while uploading the file.",
         )
-    
+
+
 @router.get(
     "",
     tags=[DEFAULT_TAG],

--- a/stack/app/api/v1/rag.py
+++ b/stack/app/api/v1/rag.py
@@ -78,12 +78,11 @@ async def ingest(
                 payload, assistant_repository
             )
 
-        for file_id in payload.files: 
+        for file_id in payload.files:
             file_model = await file_repository.retrieve_file(file_id)
             file = FileSchema.model_validate(file_model)
             file_content = await file_repository.retrieve_file_content(str(file_id))
             files_to_ingest.append((file, file_content))
-
 
         tasks = await get_ingest_tasks_from_config(files_to_ingest, payload)
 

--- a/stack/app/api/v1/rag.py
+++ b/stack/app/api/v1/rag.py
@@ -81,7 +81,6 @@ async def ingest(
         for file_id in payload.files: 
             file_model = await file_repository.retrieve_file(file_id)
             file = FileSchema.model_validate(file_model)
-            # files_to_ingest.append(file)
             file_content = await file_repository.retrieve_file_content(str(file_id))
             files_to_ingest.append((file, file_content))
 

--- a/stack/app/api/v1/rag.py
+++ b/stack/app/api/v1/rag.py
@@ -78,10 +78,13 @@ async def ingest(
                 payload, assistant_repository
             )
 
-        for file_id in payload.files:
-            file_model = await file_repository.retrieve_file(UUID(file_id))
+        for file_id in payload.files: 
+            file_model = await file_repository.retrieve_file(file_id)
             file = FileSchema.model_validate(file_model)
-            files_to_ingest.append(file)
+            # files_to_ingest.append(file)
+            file_content = await file_repository.retrieve_file_content(str(file_id))
+            files_to_ingest.append((file, file_content))
+
 
         tasks = await get_ingest_tasks_from_config(files_to_ingest, payload)
 

--- a/stack/app/core/configuration.py
+++ b/stack/app/core/configuration.py
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
         if ENVIRONMENT != EnvironmentEnum.PRODUCTION
         else LogLevelEnum.ERROR
     )
-    
+
     BASE_DIR: Path = Path(__file__).parents[2]
     APP_DIR: Path = BASE_DIR.joinpath("stack")
     FILE_DATA_DIRECTORY: Path = BASE_DIR.parent.joinpath("file_data")
@@ -161,7 +161,9 @@ class Settings(BaseSettings):
     VECTOR_DB_HOST: str = os.getenv("VECTOR_DB_HOST", "localhost")
     VECTOR_DB_PORT: str | int = os.getenv("VECTOR_DB_PORT", 6333)
     VECTOR_DB_COLLECTION_NAME: str = os.getenv("VECTOR_DB_COLLECTION_NAME", "documents")
-    VECTOR_DB_ENCODER_DIMENSIONS: str | int = os.getenv("VECTOR_DB_ENCODER_DIMENSIONS", 1536)
+    VECTOR_DB_ENCODER_DIMENSIONS: str | int = os.getenv(
+        "VECTOR_DB_ENCODER_DIMENSIONS", 1536
+    )
     VECTOR_DB_ENCODER_MODEL: str = os.getenv(
         "VECTOR_DB_ENCODER_MODEL", "text-embedding-3-small"
     )

--- a/stack/app/core/configuration.py
+++ b/stack/app/core/configuration.py
@@ -49,7 +49,7 @@ class Settings(BaseSettings):
     TITLE: str = "PersonaFlow"
     VERSION: str = "0.1.0"
     DESCRIPTION: str = "PersonaFlow API"
-    ENVIRONMENT: EnvironmentEnum = os.getenv("ENVIRONMENT", "PRODUCTION")
+    ENVIRONMENT: str | EnvironmentEnum = os.getenv("ENVIRONMENT", EnvironmentEnum.LOCAL)
     LOG_LEVEL: LogLevelEnum = (
         LogLevelEnum.DEBUG
         if ENVIRONMENT != EnvironmentEnum.PRODUCTION
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
     JWT_ISSUER: Optional[str] = os.getenv("JWT_ISSUER", None)
     JWT_ALGORITHM: Optional[str] = os.getenv("JWT_ALGORITHM", "HS256")
     AUTH_SECRET_KEY: Optional[str] = os.getenv("AUTH_SECRET_KEY", "secret")
-    TOKEN_EXPIRY_HOURS: Optional[int] = os.getenv("TOKEN_EXPIRY_HOURS", 24)
+    TOKEN_EXPIRY_HOURS: Optional[str | int] = os.getenv("TOKEN_EXPIRY_HOURS", 24)
 
     # Required if you intend to use reranking functionality to query documents
     COHERE_API_KEY: Optional[str] = os.getenv("COHERE_API_KEY", None)
@@ -87,7 +87,7 @@ class Settings(BaseSettings):
     TAVILY_API_KEY: Optional[str] = os.getenv("TAVILY_API_KEY", None)
 
     # Number of iterations assistant is allowed to run to accomplish task or improve results or response (Required)
-    LANGGRAPH_RECURSION_LIMIT: int = os.getenv("LANGGRAPH_RECURSION_LIMIT", 25)
+    LANGGRAPH_RECURSION_LIMIT: str | int = os.getenv("LANGGRAPH_RECURSION_LIMIT", 25)
 
     EXCLUDE_REQUEST_LOG_ENDPOINTS: list[str] = ["/docs"]
 
@@ -100,7 +100,7 @@ class Settings(BaseSettings):
         "INTERNAL_DATABASE_PASSWORD", "postgres"
     )
     INTERNAL_DATABASE_HOST: str = os.getenv("INTERNAL_DATABASE_HOST", "localhost")
-    INTERNAL_DATABASE_PORT: int = os.getenv("INTERNAL_DATABASE_PORT", 5432)
+    INTERNAL_DATABASE_PORT: str | int = os.getenv("INTERNAL_DATABASE_PORT", 5432)
     INTERNAL_DATABASE_DATABASE: str = os.getenv(
         "INTERNAL_DATABASE_DATABASE", "internal"
     )
@@ -159,9 +159,9 @@ class Settings(BaseSettings):
     VECTOR_DB_API_KEY: str = os.getenv("VECTOR_DB_API_KEY", "")
     VECTOR_DB_NAME: str = os.getenv("VECTOR_DB_NAME", "qdrant")
     VECTOR_DB_HOST: str = os.getenv("VECTOR_DB_HOST", "localhost")
-    VECTOR_DB_PORT: int = os.getenv("VECTOR_DB_PORT", 6333)
-    VECTOR_DB_COLLECTION_NAME: str = os.getenv("VECTOR_DB_COLLECTION_NAME", "test")
-    VECTOR_DB_ENCODER_DIMENSIONS: int = os.getenv("VECTOR_DB_ENCODER_DIMENSIONS", 1536)
+    VECTOR_DB_PORT: str | int = os.getenv("VECTOR_DB_PORT", 6333)
+    VECTOR_DB_COLLECTION_NAME: str = os.getenv("VECTOR_DB_COLLECTION_NAME", "documents")
+    VECTOR_DB_ENCODER_DIMENSIONS: str | int = os.getenv("VECTOR_DB_ENCODER_DIMENSIONS", 1536)
     VECTOR_DB_ENCODER_MODEL: str = os.getenv(
         "VECTOR_DB_ENCODER_MODEL", "text-embedding-3-small"
     )

--- a/stack/app/core/configuration.py
+++ b/stack/app/core/configuration.py
@@ -52,10 +52,10 @@ class Settings(BaseSettings):
     ENVIRONMENT: EnvironmentEnum = os.getenv("ENVIRONMENT", "PRODUCTION")
     LOG_LEVEL: LogLevelEnum = (
         LogLevelEnum.DEBUG
-        if ENVIRONMENT == EnvironmentEnum.LOCAL
+        if ENVIRONMENT != EnvironmentEnum.PRODUCTION
         else LogLevelEnum.ERROR
     )
-
+    
     BASE_DIR: Path = Path(__file__).parents[2]
     APP_DIR: Path = BASE_DIR.joinpath("stack")
     FILE_DATA_DIRECTORY: Path = BASE_DIR.parent.joinpath("file_data")
@@ -149,7 +149,7 @@ class Settings(BaseSettings):
         "accounts/fireworks/models/mixtral-8x7b-instruct",
     )
 
-    OLLAMA_MODEL: Optional[str] = os.getenv("OLLAMA_MODEL", "llama3")
+    OLLAMA_MODEL: Optional[str] = os.getenv("OLLAMA_MODEL", "llama3.1")
     OLLAMA_BASE_URL: Optional[str] = os.getenv(
         "OLLAMA_BASE_URL", "http://localhost:11434"
     )
@@ -160,7 +160,7 @@ class Settings(BaseSettings):
     VECTOR_DB_NAME: str = os.getenv("VECTOR_DB_NAME", "qdrant")
     VECTOR_DB_HOST: str = os.getenv("VECTOR_DB_HOST", "localhost")
     VECTOR_DB_PORT: int = os.getenv("VECTOR_DB_PORT", 6333)
-    VECTOR_DB_COLLECTION_NAME: str = os.getenv("VECTOR_DB_COLLECTION_NAME", "documents")
+    VECTOR_DB_COLLECTION_NAME: str = os.getenv("VECTOR_DB_COLLECTION_NAME", "test")
     VECTOR_DB_ENCODER_DIMENSIONS: int = os.getenv("VECTOR_DB_ENCODER_DIMENSIONS", 1536)
     VECTOR_DB_ENCODER_MODEL: str = os.getenv(
         "VECTOR_DB_ENCODER_MODEL", "text-embedding-3-small"

--- a/stack/app/rag/custom_retriever.py
+++ b/stack/app/rag/custom_retriever.py
@@ -41,9 +41,5 @@ class Retriever(BaseRetriever):
         return [self._chunk_to_document(chunk) for chunk in chunks]
 
     def _chunk_to_document(self, chunk: BaseDocumentChunk) -> Document:
-        metadata = {
-            "namespace": chunk.namespace,
-            **chunk.metadata
-        }
+        metadata = {"namespace": chunk.namespace, **chunk.metadata}
         return Document(page_content=chunk.page_content, metadata=metadata)
-

--- a/stack/app/rag/custom_retriever.py
+++ b/stack/app/rag/custom_retriever.py
@@ -42,9 +42,8 @@ class Retriever(BaseRetriever):
 
     def _chunk_to_document(self, chunk: BaseDocumentChunk) -> Document:
         metadata = {
-            "source": chunk.source,
-            "file_id": chunk.file_id,
-            "chunk_index": chunk.chunk_index,
             "namespace": chunk.namespace,
+            **chunk.metadata
         }
         return Document(page_content=chunk.page_content, metadata=metadata)
+

--- a/stack/app/rag/encoders/ollama_encoder.py
+++ b/stack/app/rag/encoders/ollama_encoder.py
@@ -6,6 +6,7 @@ from stack.app.core.configuration import get_settings
 
 settings = get_settings()
 
+
 class OllamaEncoder(BaseEncoder):
     name: str = Field(default="all-minilm")
     score_threshold: float = Field(default=0.5)
@@ -18,12 +19,10 @@ class OllamaEncoder(BaseEncoder):
 
     def __init__(self, **data):
         super().__init__(**data)
-        if 'name' in data:
+        if "name" in data:
             self.embeddings = OllamaEmbeddings(
-                model=self.name,
-                base_url=settings.OLLAMA_BASE_URL
+                model=self.name, base_url=settings.OLLAMA_BASE_URL
             )
 
     def __call__(self, docs: List[str]) -> List[List[float]]:
         return self.embeddings.embed_documents(docs)
-

--- a/stack/app/rag/encoders/ollama_encoder.py
+++ b/stack/app/rag/encoders/ollama_encoder.py
@@ -1,24 +1,29 @@
 from typing import List
-
+from pydantic import Field
 from semantic_router.encoders import BaseEncoder
-from langchain_community.embeddings.ollama import OllamaEmbeddings
-
+from langchain_community.embeddings import OllamaEmbeddings
 from stack.app.core.configuration import get_settings
 
 settings = get_settings()
 
-
-def get_ollama_embeddings():
-    return OllamaEmbeddings(
-        model=settings.VECTOR_DB_ENCODER_MODEL, base_url=settings.OLLAMA_BASE_URL
-    )
-
-
 class OllamaEncoder(BaseEncoder):
-    name = "OllamaEncoder"
-    score_threshold = 0.5
-    type = "ollama"
-    embeddings = get_ollama_embeddings()
+    name: str = Field(default="all-minilm")
+    score_threshold: float = Field(default=0.75)
+    type: str = Field(default="ollama")
+    dimensions: int = Field(default=384)
+    embeddings: OllamaEmbeddings = Field(default=None)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        if 'name' in data:
+            self.embeddings = OllamaEmbeddings(
+                model=self.name,
+                base_url=settings.OLLAMA_BASE_URL
+            )
 
     def __call__(self, docs: List[str]) -> List[List[float]]:
         return self.embeddings.embed_documents(docs)
+

--- a/stack/app/rag/encoders/ollama_encoder.py
+++ b/stack/app/rag/encoders/ollama_encoder.py
@@ -8,7 +8,7 @@ settings = get_settings()
 
 class OllamaEncoder(BaseEncoder):
     name: str = Field(default="all-minilm")
-    score_threshold: float = Field(default=0.75)
+    score_threshold: float = Field(default=0.5)
     type: str = Field(default="ollama")
     dimensions: int = Field(default=384)
     embeddings: OllamaEmbeddings = Field(default=None)

--- a/stack/app/rag/ingest.py
+++ b/stack/app/rag/ingest.py
@@ -30,7 +30,7 @@ async def get_ingest_tasks_from_config(
         files=files_to_ingest,
         namespace=namespace,
         purpose=config.purpose,
-        parser_config=config.parser_config,
+        parser_config=document_processor_config.parser_config,
     )
 
     chunks = await embedding_service.generate_chunks(config=document_processor_config)

--- a/stack/app/rag/ingest.py
+++ b/stack/app/rag/ingest.py
@@ -29,6 +29,8 @@ async def get_ingest_tasks_from_config(
         dimensions=document_processor_config.encoder.dimensions,
         files=files_to_ingest,
         namespace=namespace,
+        purpose=config.purpose,
+        parser_config=config.parser_config,
     )
 
     chunks = await embedding_service.generate_chunks(config=document_processor_config)

--- a/stack/app/rag/ingest.py
+++ b/stack/app/rag/ingest.py
@@ -11,7 +11,7 @@ settings = get_settings()
 
 
 async def get_ingest_tasks_from_config(
-    files_to_ingest: list[FileSchema],
+    files_to_ingest: list[tuple[FileSchema, bytes]],
     config: IngestRequestPayload,
 ) -> list:
     vector_db_creds = config.vector_database

--- a/stack/app/rag/splitter.py
+++ b/stack/app/rag/splitter.py
@@ -126,10 +126,12 @@ class UnstructuredSemanticSplitter:
     ):
         chunks_with_title.append(
             {
-                "title": title,
                 "page_content": page_content,
-                "chunk_index": chunk_index,
-                "metadata": metadata,
+                "metadata": {
+                    **metadata,
+                    "title": title,
+                    "chunk_index": chunk_index,
+                }
             }
         )
 

--- a/stack/app/rag/splitter.py
+++ b/stack/app/rag/splitter.py
@@ -131,7 +131,7 @@ class UnstructuredSemanticSplitter:
                     **metadata,
                     "title": title,
                     "chunk_index": chunk_index,
-                }
+                },
             }
         )
 

--- a/stack/app/repositories/file.py
+++ b/stack/app/repositories/file.py
@@ -27,36 +27,51 @@ class FileRepository(BaseRepository):
     def __init__(self, postgresql_session):
         self.postgresql_session = postgresql_session
 
+
     async def create_file(self, data: dict, file_content: bytes) -> File:
         try:
-            # Guess the mime type and file extension
-            mime_type = guess_mime_type(data.get("filename", ""), file_content)
-            file_extension = guess_file_extension(
-                data.get("filename", ""), file_content
-            )
+            original_filename = data.get("filename")
+            if not original_filename:
+                raise ValueError("Filename is required")
+            
+            logger.info(f"Creating file: {original_filename}")
+            
+            # Guess the mime type using the original filename
+            mime_type = guess_mime_type(original_filename, file_content)
+            logger.info(f"Guessed mime type: {mime_type}")
+            
+            # Get the file extension from the original filename
+            _, file_extension = os.path.splitext(original_filename)
+            if not file_extension:
+                file_extension = f".{guess_file_extension(original_filename, file_content)}"
+            logger.info(f"File extension: {file_extension}")
 
             # Update the data dictionary with the guessed mime type
             data["mime_type"] = mime_type
 
+            # Generate a new UUID for the file
+            file_id = uuid.uuid4()
+
+            # Create the new filename using the UUID and original extension
+            new_filename = f"{file_id}{file_extension}"
+            file_path = os.path.join(settings.FILE_DATA_DIRECTORY, new_filename)
+
+            # Update the data with the new file information
+            data["id"] = file_id
+            data["source"] = file_path
+
+            # Create the file record in the database
             file = await self.create(model=File, values=data)
             await self.postgresql_session.commit()
 
             # Create the file data directory if it doesn't exist
             os.makedirs(settings.FILE_DATA_DIRECTORY, exist_ok=True)
 
-            # Save the file content to the local file system using the generated UUID
-            local_file_name = f"{file.id}.{file_extension}"
-            file_path = os.path.join(settings.FILE_DATA_DIRECTORY, local_file_name)
-
+            # Save the file content to the local file system
             with open(file_path, "wb") as f:
                 f.write(file_content)
 
-            # update the file record with the "source" field set to file_path
-            update_file = await self.update(
-                model=File, values={"source": file_path}, object_id=file.id
-            )
-            await self.postgresql_session.commit()
-            return update_file
+            return file
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
             logger.exception(
@@ -67,7 +82,16 @@ class FileRepository(BaseRepository):
             raise HTTPException(
                 status_code=400, detail=f"Failed to create file: {e}."
             ) from e
-
+        except ValueError as e:
+            logger.exception(
+                f"Failed to create file due to a value error: {e}.",
+                exc_info=True,
+                file_data=data,
+            )
+            raise HTTPException(
+                status_code=400, detail=str(e)
+            ) from e
+            
     @staticmethod
     def _get_retrieve_query() -> select:
         """A private method to construct the default query for file

--- a/stack/app/repositories/file.py
+++ b/stack/app/repositories/file.py
@@ -33,30 +33,21 @@ class FileRepository(BaseRepository):
             original_filename = data.get("filename")
             if not original_filename:
                 raise ValueError("Filename is required")
-            
-            logger.info(f"Creating file: {original_filename}")
-            
+                        
             # Guess the mime type using the original filename
             mime_type = guess_mime_type(original_filename, file_content)
-            logger.info(f"Guessed mime type: {mime_type}")
             
             # Get the file extension from the original filename
             _, file_extension = os.path.splitext(original_filename)
             if not file_extension:
                 file_extension = f".{guess_file_extension(original_filename, file_content)}"
-            logger.info(f"File extension: {file_extension}")
 
-            # Update the data dictionary with the guessed mime type
             data["mime_type"] = mime_type
 
-            # Generate a new UUID for the file
             file_id = uuid.uuid4()
-
             # Create the new filename using the UUID and original extension
             new_filename = f"{file_id}{file_extension}"
             file_path = os.path.join(settings.FILE_DATA_DIRECTORY, new_filename)
-
-            # Update the data with the new file information
             data["id"] = file_id
             data["source"] = file_path
 
@@ -67,11 +58,11 @@ class FileRepository(BaseRepository):
             # Create the file data directory if it doesn't exist
             os.makedirs(settings.FILE_DATA_DIRECTORY, exist_ok=True)
 
-            # Save the file content to the local file system
             with open(file_path, "wb") as f:
                 f.write(file_content)
 
             return file
+        
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
             logger.exception(

--- a/stack/app/repositories/file.py
+++ b/stack/app/repositories/file.py
@@ -27,20 +27,21 @@ class FileRepository(BaseRepository):
     def __init__(self, postgresql_session):
         self.postgresql_session = postgresql_session
 
-
     async def create_file(self, data: dict, file_content: bytes) -> File:
         try:
             original_filename = data.get("filename")
             if not original_filename:
                 raise ValueError("Filename is required")
-                        
+
             # Guess the mime type using the original filename
             mime_type = guess_mime_type(original_filename, file_content)
-            
+
             # Get the file extension from the original filename
             _, file_extension = os.path.splitext(original_filename)
             if not file_extension:
-                file_extension = f".{guess_file_extension(original_filename, file_content)}"
+                file_extension = (
+                    f".{guess_file_extension(original_filename, file_content)}"
+                )
 
             data["mime_type"] = mime_type
 
@@ -62,7 +63,7 @@ class FileRepository(BaseRepository):
                 f.write(file_content)
 
             return file
-        
+
         except SQLAlchemyError as e:
             await self.postgresql_session.rollback()
             logger.exception(
@@ -79,10 +80,8 @@ class FileRepository(BaseRepository):
                 exc_info=True,
                 file_data=data,
             )
-            raise HTTPException(
-                status_code=400, detail=str(e)
-            ) from e
-            
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
     @staticmethod
     def _get_retrieve_query() -> select:
         """A private method to construct the default query for file

--- a/stack/app/schema/file.py
+++ b/stack/app/schema/file.py
@@ -94,10 +94,6 @@ class UploadFileSchema(BaseModel):
         default=ContextType.assistants,
         description="The context for file: eg. 'assistants', 'rag', 'threads', or 'personas'.",
     )
-    filename: Optional[str] = Field(
-        None,
-        description="The preferred name for the file. If not provided, the name of the uploaded file will be used.",
-    )
     kwargs: Optional[str] = Field(
         None,
         description="The file kwargs, containing any additional information about the file. This is a string sent in JSON format.",

--- a/stack/app/schema/rag.py
+++ b/stack/app/schema/rag.py
@@ -163,6 +163,11 @@ class DocumentProcessorConfig(BaseModel):
         description="Document partition manager configuration. If not provided, this comes from the env config.",
     )
 
+class ParserConfig(BaseModel):
+    structured_data_content_field: Optional[str] = Field(
+        default="page_content", 
+        description="For JSON and CSV files: the field name containing the content to be embedded. All other fields will be saved as metadata."
+    )
 
 class IngestRequestPayload(BaseModel):
     files: list[uuid.UUID] = Field(..., description="An array of file ids to ingest")
@@ -190,7 +195,9 @@ class IngestRequestPayload(BaseModel):
         None,
         description="Webhook url to send the notification to when the ingestion is completed.",
     )
-
+    parser_config: Optional[ParserConfig] = Field(
+        default=ParserConfig(),
+        description="Content-specific keyword arguments for processing")
 
 # Query Schemas
 class QueryRequestPayload(BaseModel):

--- a/stack/app/schema/rag.py
+++ b/stack/app/schema/rag.py
@@ -154,7 +154,12 @@ class SplitterConfig(BaseModel):
         default=settings.PREFIX_SUMMARY, description="Add to split sub-document summary"
     )
 
-
+class ParserConfig(BaseModel):
+    structured_data_content_field: Optional[str] = Field(
+        default="page_content", 
+        description="For JSON and CSV files: the field name containing the content to be embedded. All other fields will be saved as metadata."
+    )
+    
 class DocumentProcessorConfig(BaseModel):
     summarize: bool = Field(
         default=settings.CREATE_SUMMARY_COLLECTION,
@@ -172,12 +177,10 @@ class DocumentProcessorConfig(BaseModel):
         default=SplitterConfig(),
         description="Document partition manager configuration. If not provided, this comes from the env config.",
     )
+    parser_config: Optional[ParserConfig] = Field(
+        default=ParserConfig(),
+        description="Content-specific keyword arguments for processing")
 
-class ParserConfig(BaseModel):
-    structured_data_content_field: Optional[str] = Field(
-        default="page_content", 
-        description="For JSON and CSV files: the field name containing the content to be embedded. All other fields will be saved as metadata."
-    )
 
 class IngestRequestPayload(BaseModel):
     files: list[uuid.UUID] = Field(..., description="An array of file ids to ingest")
@@ -205,9 +208,7 @@ class IngestRequestPayload(BaseModel):
         None,
         description="Webhook url to send the notification to when the ingestion is completed.",
     )
-    parser_config: Optional[ParserConfig] = Field(
-        default=ParserConfig(),
-        description="Content-specific keyword arguments for processing")
+    
 
 # Query Schemas
 class QueryRequestPayload(BaseModel):

--- a/stack/app/schema/rag.py
+++ b/stack/app/schema/rag.py
@@ -63,6 +63,10 @@ class EncoderConfig(BaseModel):
         default=settings.VECTOR_DB_ENCODER_DIMENSIONS,
         description="Dimension of the encoder output",
     )
+    score_threshold: float = Field(
+        default=0.5,
+        description="Score threshold for the encoder",
+    )
 
     @classmethod
     def get_encoder_config(cls, encoder_provider: EncoderProvider):
@@ -71,26 +75,31 @@ class EncoderConfig(BaseModel):
                 "class": CohereEncoder,
                 "default_model_name": "embed-multilingual-light-v3.0",
                 "default_dimensions": 384,
+                "default_score_threshold": 0.3,
             },
             EncoderProvider.openai: {
                 "class": OpenAIEncoder,
                 "default_model_name": "text-embedding-3-small",
                 "default_dimensions": 1536,
+                "default_score_threshold": 0.82,
             },
             EncoderProvider.ollama: {
                 "class": OllamaEncoder,
                 "default_model_name": "all-minilm",
                 "default_dimensions": 384,
+                "default_score_threshold": 0.67,
             },
             EncoderProvider.azure_openai: {
                 "class": AzureOpenAIEncoder,
                 "default_model_name": "text-embedding-3-small",
                 "default_dimensions": 1536,
+                "default_score_threshold": 0.82,
             },
             EncoderProvider.mistral: {
                 "class": MistralEncoder,
                 "default_model_name": "mistral-embed",
                 "default_dimensions": 1024,
+                "default_score_threshold": 0.82,
             },
         }
         return encoder_configs.get(encoder_provider)
@@ -101,8 +110,9 @@ class EncoderConfig(BaseModel):
             raise ValueError(f"Encoder '{self.provider}' not found.")
         encoder_model = self.encoder_model or encoder_config["default_model_name"]
         dimensions = self.dimensions or encoder_config["default_dimensions"]
+        score_threshold=self.score_threshold or encoder_config["default_score_threshold"]
         encoder_class = encoder_config["class"]
-        return encoder_class(name=encoder_model, dimensions=dimensions)
+        return encoder_class(name=encoder_model, dimensions=dimensions, score_threshold=score_threshold)
 
 
 class UnstructuredConfig(BaseModel):

--- a/stack/app/schema/rag.py
+++ b/stack/app/schema/rag.py
@@ -110,9 +110,13 @@ class EncoderConfig(BaseModel):
             raise ValueError(f"Encoder '{self.provider}' not found.")
         encoder_model = self.encoder_model or encoder_config["default_model_name"]
         dimensions = self.dimensions or encoder_config["default_dimensions"]
-        score_threshold=self.score_threshold or encoder_config["default_score_threshold"]
+        score_threshold = (
+            self.score_threshold or encoder_config["default_score_threshold"]
+        )
         encoder_class = encoder_config["class"]
-        return encoder_class(name=encoder_model, dimensions=dimensions, score_threshold=score_threshold)
+        return encoder_class(
+            name=encoder_model, dimensions=dimensions, score_threshold=score_threshold
+        )
 
 
 class UnstructuredConfig(BaseModel):
@@ -154,12 +158,14 @@ class SplitterConfig(BaseModel):
         default=settings.PREFIX_SUMMARY, description="Add to split sub-document summary"
     )
 
+
 class ParserConfig(BaseModel):
     structured_data_content_field: Optional[str] = Field(
-        default="page_content", 
-        description="For JSON and CSV files: the field name containing the content to be embedded. All other fields will be saved as metadata."
+        default="page_content",
+        description="For JSON and CSV files: the field name containing the content to be embedded. All other fields will be saved as metadata.",
     )
-    
+
+
 class DocumentProcessorConfig(BaseModel):
     summarize: bool = Field(
         default=settings.CREATE_SUMMARY_COLLECTION,
@@ -179,7 +185,8 @@ class DocumentProcessorConfig(BaseModel):
     )
     parser_config: Optional[ParserConfig] = Field(
         default=ParserConfig(),
-        description="Content-specific keyword arguments for processing")
+        description="Content-specific keyword arguments for processing",
+    )
 
 
 class IngestRequestPayload(BaseModel):
@@ -208,7 +215,7 @@ class IngestRequestPayload(BaseModel):
         None,
         description="Webhook url to send the notification to when the ingestion is completed.",
     )
-    
+
 
 # Query Schemas
 class QueryRequestPayload(BaseModel):
@@ -251,7 +258,6 @@ class BaseDocument(BaseModel):
     metadata: dict | None = None
 
 
-
 class BaseDocumentChunk(BaseModel):
     id: str
     page_content: str
@@ -265,14 +271,14 @@ class BaseDocumentChunk(BaseModel):
         chunk_id = metadata.pop("chunk_id", "")
         page_content = metadata.pop("page_content", "")
         namespace = metadata.pop("namespace", None)
-        
+
         # Everything else goes into metadata
         return cls(
             id=chunk_id,
             page_content=page_content,
             namespace=namespace,
             metadata=metadata,
-            dense_embedding=metadata.pop("values", None)
+            dense_embedding=metadata.pop("values", None),
         )
 
     @classmethod
@@ -304,7 +310,7 @@ class BaseDocumentChunk(BaseModel):
             "metadata": {
                 "page_content": self.page_content,
                 "namespace": self.namespace,
-                **self.metadata
+                **self.metadata,
             },
         }
 
@@ -314,7 +320,7 @@ class BaseDocumentChunk(BaseModel):
             "page_content": self.page_content,
             "namespace": self.namespace,
             "metadata": self.metadata,
-            "dense_embedding": self.dense_embedding
+            "dense_embedding": self.dense_embedding,
         }
 
 

--- a/stack/app/schema/rag.py
+++ b/stack/app/schema/rag.py
@@ -244,114 +244,11 @@ class QueryRequestPayload(BaseModel):
     )
 
 
-# Documents
-
-
 class BaseDocument(BaseModel):
     id: str
     page_content: str
     metadata: dict | None = None
 
-
-# class BaseDocumentChunk(BaseModel):
-#     id: str
-#     document_id: str
-#     page_content: str
-#     file_id: str | None = None
-#     namespace: str | None = None
-#     source: str | None = None
-#     source_type: str | None = None
-#     chunk_index: int | None = None
-#     title: str | None = None
-#     purpose: ContextType | None = None
-#     token_count: int | None = None
-#     page_number: int | None = None
-#     metadata: dict | None = None
-#     dense_embedding: Optional[list[float]] = None
-
-#     @classmethod
-#     def from_metadata(cls, metadata: dict):
-#         exclude_keys = {
-#             "chunk_id",
-#             "chunk_index",
-#             "document_id",
-#             "file_id",
-#             "namespace",
-#             "page_content",
-#             "source",
-#             "source_type",
-#             "purpose",
-#             "title",
-#             "token_count",
-#             "page_number",
-#         }
-#         # Prepare metadata for the constructor and for embedding into the object
-#         constructor_metadata = {
-#             k: v for k, v in metadata.items() if k not in exclude_keys
-#         }
-#         filtered_metadata = {
-#             k: v for k, v in metadata.items() if k in exclude_keys and k != "chunk_id"
-#         }
-
-#         def to_int(value):
-#             try:
-#                 return int(value) if str(value).isdigit() else None
-#             except (TypeError, ValueError):
-#                 return None
-
-#         chunk_index = to_int(metadata.get("chunk_index"))
-#         token_count = to_int(metadata.get("token_count"))
-
-#         # Remove explicitly passed keys from filtered_metadata to avoid duplication
-#         for key in ["chunk_index", "token_count"]:
-#             filtered_metadata.pop(key, None)
-
-#         return cls(
-#             id=metadata.get("chunk_id", ""),
-#             chunk_index=chunk_index,
-#             token_count=token_count,
-#             **filtered_metadata,  # Pass filtered metadata for constructor
-#             metadata=constructor_metadata,  # Pass the rest as part of the metadata
-#             dense_embedding=metadata.get("values"),
-#         )
-
-#     @validator("id")
-#     def id_must_be_valid_uuid(cls, v):
-#         try:
-#             uuid_obj = uuid.UUID(v, version=4)
-#             return str(uuid_obj)
-#         except ValueError:
-#             raise ValueError(f"id must be a valid UUID, got {v}")
-
-#     @validator("dense_embedding")
-#     def embeddings_must_be_list_of_floats(cls, v):
-#         if v is None:
-#             return v  # Allow None to pass through
-#         if not all(isinstance(item, float) for item in v):
-#             raise ValueError(f"embeddings must be a list of floats, got {v}")
-#         return v
-
-#     def to_vector_db(self):
-#         metadata = {
-#             "chunk_id": self.id,
-#             "chunk_index": self.chunk_index or "",
-#             "document_id": self.document_id,
-#             "file_id": self.file_id,
-#             "namespace": self.namespace,
-#             "page_content": self.page_content,
-#             "source": self.source,
-#             "source_type": self.source_type,
-#             "title": self.title or "",
-#             "purpose": self.purpose,
-#             "token_count": self.token_count,
-#             **(self.metadata or {}),
-#         }
-#         result = {
-#             "id": self.id,
-#             "values": self.dense_embedding,
-#             "metadata": metadata,
-#         }
-#         return result
 
 
 class BaseDocumentChunk(BaseModel):

--- a/stack/app/utils/file_helpers.py
+++ b/stack/app/utils/file_helpers.py
@@ -28,6 +28,8 @@ MIMETYPE_BASED_PARSER = MimeTypeBasedParser(
     handlers=HANDLERS,
     fallback_parser=None,
 )
+
+
 def guess_mime_type(file_name: str, file_bytes: bytes) -> str:
     """Guess the mime-type of a file based on its name or bytes."""
     # Guess based on the file extension
@@ -53,8 +55,9 @@ def guess_mime_type(file_name: str, file_bytes: bytes) -> str:
     try:
         decoded = file_bytes[:1024].decode("utf-8", errors="ignore")
         stripped = decoded.strip()
-        if (stripped.startswith('{') and stripped.endswith('}')) or \
-           (stripped.startswith('[') and stripped.endswith(']')):
+        if (stripped.startswith("{") and stripped.endswith("}")) or (
+            stripped.startswith("[") and stripped.endswith("]")
+        ):
             return "application/json"
     except UnicodeDecodeError:
         pass
@@ -107,19 +110,21 @@ def is_mime_type_supported(mime_type: str) -> bool:
     """Check if the mime type is supported."""
     return mime_type in SUPPORTED_MIMETYPES
 
+
 def parse_json_file(file_content: bytes) -> list:
     try:
-        data = json.loads(file_content.decode('utf-8'))
+        data = json.loads(file_content.decode("utf-8"))
         if isinstance(data, list):
             return data
         else:
             raise ValueError("JSON file must contain an array of objects")
     except json.JSONDecodeError:
         raise ValueError("Invalid JSON file")
-    
+
+
 def parse_csv_file(file_content: bytes) -> list:
     try:
-        csv_content = file_content.decode('utf-8')
+        csv_content = file_content.decode("utf-8")
         csv_reader = csv.DictReader(io.StringIO(csv_content))
         return list(csv_reader)
     except csv.Error:

--- a/stack/app/utils/file_helpers.py
+++ b/stack/app/utils/file_helpers.py
@@ -1,5 +1,7 @@
 import mimetypes
 import json
+import csv
+import io
 from langchain.document_loaders.parsers import BS4HTMLParser, PDFMinerParser
 from langchain.document_loaders.parsers.generic import MimeTypeBasedParser
 from langchain.document_loaders.parsers.msword import MsWordParser
@@ -114,3 +116,11 @@ def parse_json_file(file_content: bytes) -> list:
             raise ValueError("JSON file must contain an array of objects")
     except json.JSONDecodeError:
         raise ValueError("Invalid JSON file")
+    
+def parse_csv_file(file_content: bytes) -> list:
+    try:
+        csv_content = file_content.decode('utf-8')
+        csv_reader = csv.DictReader(io.StringIO(csv_content))
+        return list(csv_reader)
+    except csv.Error:
+        raise ValueError("Invalid CSV file")

--- a/stack/app/utils/file_helpers.py
+++ b/stack/app/utils/file_helpers.py
@@ -1,5 +1,5 @@
 import mimetypes
-import re
+import json
 from langchain.document_loaders.parsers import BS4HTMLParser, PDFMinerParser
 from langchain.document_loaders.parsers.generic import MimeTypeBasedParser
 from langchain.document_loaders.parsers.msword import MsWordParser
@@ -104,3 +104,13 @@ def get_file_handler(mime_type: str):
 def is_mime_type_supported(mime_type: str) -> bool:
     """Check if the mime type is supported."""
     return mime_type in SUPPORTED_MIMETYPES
+
+def parse_json_file(file_content: bytes) -> list:
+    try:
+        data = json.loads(file_content.decode('utf-8'))
+        if isinstance(data, list):
+            return data
+        else:
+            raise ValueError("JSON file must contain an array of objects")
+    except json.JSONDecodeError:
+        raise ValueError("Invalid JSON file")

--- a/stack/app/vectordbs/qdrant.py
+++ b/stack/app/vectordbs/qdrant.py
@@ -63,7 +63,7 @@ class QdrantService(BaseVectorDatabase):
                     payload={
                         "page_content": chunk.page_content,
                         "namespace": chunk.namespace,
-                        "metadata": chunk.metadata
+                        "metadata": chunk.metadata,
                     },
                 )
             )
@@ -101,7 +101,11 @@ class QdrantService(BaseVectorDatabase):
                 id=result.id,
                 page_content=result.payload.get("page_content", ""),
                 namespace=result.payload.get("namespace"),
-                metadata={k: v for k, v in result.payload.items() if k not in ["page_content", "namespace"]}
+                metadata={
+                    k: v
+                    for k, v in result.payload.items()
+                    if k not in ["page_content", "namespace"]
+                },
             )
             for result in search_result
         ]

--- a/stack/tests/integration/PersonaFlow.postman_collection.json
+++ b/stack/tests/integration/PersonaFlow.postman_collection.json
@@ -1,5365 +1,6137 @@
 {
-  "info": {
-    "_postman_id": "711b1f9f-6bcb-4650-b362-c7bdcc0e74eb",
-    "name": "PersonaFlow",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "16936331",
-    "_collection_link": "https://winter-resonance-224282.postman.co/workspace/5a05c830-9309-4e81-bbbb-50425c42988f/collection/16936331-711b1f9f-6bcb-4650-b362-c7bdcc0e74eb?action=share&source=collection_link&creator=16936331"
-  },
-  "item": [
-    {
-      "name": "api/v1",
-      "item": [
-        {
-          "name": "runs",
-          "item": [
-            {
-              "name": "Create a run",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/runs",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "runs"]
-                },
-                "description": "Create a run to be processed by the LLM."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "\"<object>\""
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Stream an LLM run.",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/runs/stream",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "runs", "stream"]
-                },
-                "description": "Endpoint to stream an LLM response. If the thread_id is not provided, a new thread will be created as long as the assistant_id is included. <br>\n                Note that the input should be a list of messages in the format: <br>\n                content: string <br>\n                role: string <br>\n                additional_kwargs: dict <br>\n                example: bool <br>"
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs/stream",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs", "stream"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs/stream",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs", "stream"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Return the input schema of the runnable.",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/runs/input_schema",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "runs", "input_schema"]
-                },
-                "description": "Return the input schema of the runnable."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs/input_schema",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs", "input_schema"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "\"<object>\""
-                }
-              ]
-            },
-            {
-              "name": "Return the output schema of the runnable.",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/runs/output_schema",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "runs", "output_schema"]
-                },
-                "description": "Return the output schema of the runnable."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs/output_schema",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs", "output_schema"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "\"<object>\""
-                }
-              ]
-            },
-            {
-              "name": "Return the config schema of the runnable.",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/runs/config_schema",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "runs", "config_schema"]
-                },
-                "description": "Return the config schema of the runnable."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs/config_schema",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs", "config_schema"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "\"<object>\""
-                }
-              ]
-            },
-            {
-              "name": "Generate a title to name the thread.",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"thread_id\": \"<string>\",\n  \"history\": [\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/runs/title",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "runs", "title"]
-                },
-                "description": "Generates a title for the conversation by sending a list of interactions to the model."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"thread_id\": \"<string>\",\n  \"history\": [\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs/title",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs", "title"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"thread_id\": \"<string>\",\n  \"history\": [\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/runs/title",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "runs", "title"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "threads",
-          "item": [
-            {
-              "name": "{thread_id}",
-              "item": [
-                {
-                  "name": "state",
-                  "item": [
-                    {
-                      "name": "Retrieve thread state",
-                      "request": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "threads",
-                            ":thread_id",
-                            "state"
-                          ],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        },
-                        "description": "Retrieves the state of a thread identified by its ID."
-                      },
-                      "response": [
-                        {
-                          "name": "Successful Response",
-                          "originalRequest": {
-                            "method": "GET",
-                            "header": [
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "threads",
-                                ":thread_id",
-                                "state"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "thread_id",
-                                  "value": "<string>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "OK",
-                          "code": 200,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{}"
-                        },
-                        {
-                          "name": "Validation Error",
-                          "originalRequest": {
-                            "method": "GET",
-                            "header": [
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "threads",
-                                ":thread_id",
-                                "state"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "thread_id",
-                                  "value": "<string>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                          "code": 422,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "Add thread state",
-                      "request": {
-                        "method": "POST",
-                        "header": [
-                          {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"values\": [\n    {\n      \"value\": \"<Error: Schema not found>\"\n    },\n    {\n      \"value\": \"<Error: Schema not found>\"\n    }\n  ],\n  \"config\": \"<object>\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "threads",
-                            ":thread_id",
-                            "state"
-                          ],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        },
-                        "description": "Adds the state of a thread identified by its ID."
-                      },
-                      "response": [
-                        {
-                          "name": "Successful Response",
-                          "originalRequest": {
-                            "method": "POST",
-                            "header": [
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "body": {
-                              "mode": "raw",
-                              "raw": "{\n  \"values\": [\n    {\n      \"value\": \"<Error: Schema not found>\"\n    },\n    {\n      \"value\": \"<Error: Schema not found>\"\n    }\n  ],\n  \"config\": \"<object>\"\n}",
-                              "options": {
-                                "raw": {
-                                  "language": "json"
-                                }
-                              }
-                            },
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "threads",
-                                ":thread_id",
-                                "state"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "thread_id",
-                                  "value": "<string>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "OK",
-                          "code": 200,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{}"
-                        },
-                        {
-                          "name": "Validation Error",
-                          "originalRequest": {
-                            "method": "POST",
-                            "header": [
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "body": {
-                              "mode": "raw",
-                              "raw": "{\n  \"values\": [\n    {\n      \"value\": \"<Error: Schema not found>\"\n    },\n    {\n      \"value\": \"<Error: Schema not found>\"\n    }\n  ],\n  \"config\": \"<object>\"\n}",
-                              "options": {
-                                "raw": {
-                                  "language": "json"
-                                }
-                              }
-                            },
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "threads",
-                                ":thread_id",
-                                "state"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "thread_id",
-                                  "value": "<string>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                          "code": 422,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "name": "Retrieve a specific thread",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "threads", ":thread_id"],
-                      "variable": [
-                        {
-                          "key": "thread_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "Retrieves detailed information about a thread identified by its ID."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "threads", ":thread_id"],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "threads", ":thread_id"],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Update a specific thread",
-                  "request": {
-                    "method": "PATCH",
-                    "header": [
-                      {
-                        "key": "Content-Type",
-                        "value": "application/json"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "threads", ":thread_id"],
-                      "variable": [
-                        {
-                          "key": "thread_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "Updates the information of a thread identified by its ID."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "PATCH",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "threads", ":thread_id"],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "PATCH",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "threads", ":thread_id"],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Delete a specific thread",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "threads", ":thread_id"],
-                      "variable": [
-                        {
-                          "key": "thread_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "Deletes a thread identified by its ID from the database."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "threads", ":thread_id"],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "No Content",
-                      "code": 204,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "threads", ":thread_id"],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Get thread history",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/threads/:thread_id/history",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "threads", ":thread_id", "history"],
-                      "variable": [
-                        {
-                          "key": "thread_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "Gets the history of the thread identified by its ID."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id/history",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "threads",
-                            ":thread_id",
-                            "history"
-                          ],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/threads/:thread_id/history",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "threads",
-                            ":thread_id",
-                            "history"
-                          ],
-                          "variable": [
-                            {
-                              "key": "thread_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "Create a new thread",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/threads",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "threads"]
-                },
-                "description": "Creates a new thread with the provided information. This can optionally be obtained from the api_key. If it is not set in the request, it will attempt to get it from the api_key."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/threads",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "threads"]
-                    }
-                  },
-                  "status": "Created",
-                  "code": 201,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/threads",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "threads"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "assistants",
-          "item": [
-            {
-              "name": "{assistant_id}",
-              "item": [
-                {
-                  "name": "files",
-                  "item": [
-                    {
-                      "name": "Add an uploaded file to an assistant for RAG.",
-                      "event": [
-                        {
-                          "listen": "prerequest",
-                          "script": {
-                            "exec": [
-                              "pm.sendRequest({",
-                              "    url: pm.environment.get(\"baseUrl\") + \"/api/v1/assistants\",",
-                              "    method: 'POST',",
-                              "    header: {",
-                              "        'X-API-KEY': pm.environment.get(\"apiKey\"),",
-                              "        'Content-Type': 'application/json'",
-                              "    },",
-                              "    body: {",
-                              "        mode: 'raw',",
-                              "        raw: JSON.stringify({",
-                              "  \"name\": \"Weather assistant\",",
-                              "  \"config\": {",
-                              "            \"configurable\": {",
-                              "                \"type\": \"chatbot\",",
-                              "                \"agent_type\": \"GPT 4o Mini\",",
-                              "                \"system_message\": \"You are a helpful weather assistant.\",",
-                              "                \"tools\": [\"DDG Search\"],",
-                              "                \"llm_type\": \"GPT 4o Mini\"",
-                              "            }",
-                              "        },",
-                              "  \"kwargs\": {",
-                              "            \"description\": \"An assistant for weather-related queries\"",
-                              "        },",
-                              "  \"public\": false",
-                              "})",
-                              "    }",
-                              "}, function (err, res) {",
-                              "    if (err) {",
-                              "        console.log(err);",
-                              "    } else {",
-                              "        const response = res.json();",
-                              "        pm.environment.set(\"assistantId\", response.id);",
-                              "    }",
-                              "});"
-                            ],
-                            "type": "text/javascript",
-                            "packages": {}
-                          }
-                        }
-                      ],
-                      "request": {
-                        "method": "POST",
-                        "header": [
-                          {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"file_id\": \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}/files",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "assistants",
-                            "{{assistantId}}",
-                            "files"
-                          ]
-                        },
-                        "description": "Convenience method to add an uploaded file to an assistant for RAG ingestion and retrieval"
-                      },
-                      "response": [
-                        {
-                          "name": "Successful Response",
-                          "originalRequest": {
-                            "method": "POST",
-                            "header": [
-                              {
-                                "key": "X-API-KEY",
-                                "value": "<API Key>",
-                                "description": "Added as a part of security scheme: apikey"
-                              },
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "body": {
-                              "mode": "raw",
-                              "raw": "{\n  \"file_id\": \"<string>\"\n}",
-                              "options": {
-                                "raw": {
-                                  "language": "json"
-                                }
-                              }
-                            },
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "assistants",
-                                ":assistant_id",
-                                "files"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "assistant_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "OK",
-                          "code": 200,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{\n  \"file_id\": \"<string>\",\n  \"assistant_id\": \"<string>\"\n}"
-                        },
-                        {
-                          "name": "Validation Error",
-                          "originalRequest": {
-                            "method": "POST",
-                            "header": [
-                              {
-                                "key": "X-API-KEY",
-                                "value": "<API Key>",
-                                "description": "Added as a part of security scheme: apikey"
-                              },
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "body": {
-                              "mode": "raw",
-                              "raw": "{\n  \"file_id\": \"<string>\"\n}",
-                              "options": {
-                                "raw": {
-                                  "language": "json"
-                                }
-                              }
-                            },
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "assistants",
-                                ":assistant_id",
-                                "files"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "assistant_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                          "code": 422,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "Retrieve file information for all files associated with an assistant",
-                      "event": [
-                        {
-                          "listen": "test",
-                          "script": {
-                            "exec": [
-                              "pm.test(\"Status code is 200\", function () {",
-                              "    pm.response.to.have.status(200);",
-                              "});",
-                              "",
-                              "pm.test(\"Response has valid JSON structure\", function () {",
-                              "    pm.response.to.be.json;",
-                              "});"
-                            ],
-                            "type": "text/javascript",
-                            "packages": {}
-                          }
-                        },
-                        {
-                          "listen": "prerequest",
-                          "script": {
-                            "exec": [
-                              "pm.variables.set(\"assistantId\", \"36395fdd-b0e3-4d4f-b9e4-38737cc6cccd\")"
-                            ],
-                            "type": "text/javascript",
-                            "packages": {}
-                          }
-                        }
-                      ],
-                      "request": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}/files",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "assistants",
-                            "{{assistantId}}",
-                            "files"
-                          ]
-                        },
-                        "description": "Returns a list of file objects for all files associated with an assistant."
-                      },
-                      "response": [
-                        {
-                          "name": "Successful Response",
-                          "originalRequest": {
-                            "method": "GET",
-                            "header": [
-                              {
-                                "key": "X-API-KEY",
-                                "value": "<API Key>",
-                                "description": "Added as a part of security scheme: apikey"
-                              },
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files?limit=20&order=desc&before=<dateTime>&after=<dateTime>",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "assistants",
-                                ":assistant_id",
-                                "files"
-                              ],
-                              "query": [
-                                {
-                                  "key": "limit",
-                                  "value": "20"
-                                },
-                                {
-                                  "key": "order",
-                                  "value": "desc"
-                                },
-                                {
-                                  "key": "before",
-                                  "value": "<dateTime>"
-                                },
-                                {
-                                  "key": "after",
-                                  "value": "<dateTime>"
-                                }
-                              ],
-                              "variable": [
-                                {
-                                  "key": "assistant_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "OK",
-                          "code": 200,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  }\n]"
-                        },
-                        {
-                          "name": "Validation Error",
-                          "originalRequest": {
-                            "method": "GET",
-                            "header": [
-                              {
-                                "key": "X-API-KEY",
-                                "value": "<API Key>",
-                                "description": "Added as a part of security scheme: apikey"
-                              },
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files?limit=20&order=desc&before=<dateTime>&after=<dateTime>",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "assistants",
-                                ":assistant_id",
-                                "files"
-                              ],
-                              "query": [
-                                {
-                                  "key": "limit",
-                                  "value": "20"
-                                },
-                                {
-                                  "key": "order",
-                                  "value": "desc"
-                                },
-                                {
-                                  "key": "before",
-                                  "value": "<dateTime>"
-                                },
-                                {
-                                  "key": "after",
-                                  "value": "<dateTime>"
-                                }
-                              ],
-                              "variable": [
-                                {
-                                  "key": "assistant_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                          "code": 422,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                        }
-                      ]
-                    },
-                    {
-                      "name": "Remove a file from an assistant",
-                      "event": [
-                        {
-                          "listen": "prerequest",
-                          "script": {
-                            "exec": [
-                              "pm.variables.set(\"assistantId\", \"36395fdd-b0e3-4d4f-b9e4-38737cc6cccd\")",
-                              "pm.variables.set(\"fileId\", \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\")"
-                            ],
-                            "type": "text/javascript",
-                            "packages": {}
-                          }
-                        }
-                      ],
-                      "request": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}/files/{{fileId}}",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "assistants",
-                            "{{assistantId}}",
-                            "files",
-                            "{{fileId}}"
-                          ]
-                        },
-                        "description": "Removes a file from an assistant by its ID. This also deletes the corresponding documents from the vector store."
-                      },
-                      "response": [
-                        {
-                          "name": "Successful Response",
-                          "originalRequest": {
-                            "method": "DELETE",
-                            "header": [
-                              {
-                                "key": "X-API-KEY",
-                                "value": "<API Key>",
-                                "description": "Added as a part of security scheme: apikey"
-                              },
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files/:file_id",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "assistants",
-                                ":assistant_id",
-                                "files",
-                                ":file_id"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "assistant_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                },
-                                {
-                                  "key": "file_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "OK",
-                          "code": 200,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 4o Mini\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
-                        },
-                        {
-                          "name": "Validation Error",
-                          "originalRequest": {
-                            "method": "DELETE",
-                            "header": [
-                              {
-                                "key": "X-API-KEY",
-                                "value": "<API Key>",
-                                "description": "Added as a part of security scheme: apikey"
-                              },
-                              {
-                                "key": "Accept",
-                                "value": "application/json"
-                              }
-                            ],
-                            "url": {
-                              "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files/:file_id",
-                              "host": ["{{baseUrl}}"],
-                              "path": [
-                                "api",
-                                "v1",
-                                "assistants",
-                                ":assistant_id",
-                                "files",
-                                ":file_id"
-                              ],
-                              "variable": [
-                                {
-                                  "key": "assistant_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                },
-                                {
-                                  "key": "file_id",
-                                  "value": "<uuid>",
-                                  "description": "(Required) "
-                                }
-                              ]
-                            }
-                          },
-                          "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                          "code": 422,
-                          "_postman_previewlanguage": "json",
-                          "header": [
-                            {
-                              "key": "Content-Type",
-                              "value": "application/json"
-                            }
-                          ],
-                          "cookie": [],
-                          "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "name": "Retrieve a specific assistant",
-                  "event": [
-                    {
-                      "listen": "prerequest",
-                      "script": {
-                        "exec": [
-                          "pm.sendRequest({",
-                          "    url: pm.environment.get(\"baseUrl\") + \"/api/v1/assistants\",",
-                          "    method: 'POST',",
-                          "    header: {",
-                          "        'X-API-KEY': pm.environment.get(\"apiKey\"),",
-                          "        'Content-Type': 'application/json'",
-                          "    },",
-                          "    body: {",
-                          "        mode: 'raw',",
-                          "        raw: JSON.stringify({",
-                          "  \"name\": \"Weather assistant\",",
-                          "  \"config\": {",
-                          "            \"configurable\": {",
-                          "                \"type\": \"chatbot\",",
-                          "                \"agent_type\": \"GPT 4o Mini\",",
-                          "                \"system_message\": \"You are a helpful weather assistant.\",",
-                          "                \"tools\": [\"DDG Search\"],",
-                          "                \"llm_type\": \"GPT 4o Mini\"",
-                          "            }",
-                          "        },",
-                          "  \"user_id\": \"asdf\",",
-                          "  \"kwargs\": {",
-                          "            \"description\": \"An assistant for weather-related queries\"",
-                          "        },",
-                          "  \"public\": false",
-                          "})",
-                          "    }",
-                          "}, function (err, res) {",
-                          "    if (err) {",
-                          "        console.log(err);",
-                          "    } else {",
-                          "        const response = res.json();",
-                          "        pm.environment.set(\"assistantId\", response.id);",
-                          "    }",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    },
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(200);",
-                          "});",
-                          "",
-                          "pm.test(\"Response has valid JSON structure\", function () {",
-                          "    pm.response.to.be.json;",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "assistants", "{{assistantId}}"]
-                    },
-                    "description": "Retrieves detailed information about a specific assistant by its ID."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "assistants", ":assistant_id"],
-                          "variable": [
-                            {
-                              "key": "assistant_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 4o Mini\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "assistants", ":assistant_id"],
-                          "variable": [
-                            {
-                              "key": "assistant_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Update a specific assistant",
-                  "event": [
-                    {
-                      "listen": "prerequest",
-                      "script": {
-                        "exec": [
-                          "pm.sendRequest({",
-                          "    url: pm.environment.get(\"baseUrl\") + \"/api/v1/assistants\",",
-                          "    method: 'POST',",
-                          "    header: {",
-                          "        'X-API-KEY': pm.environment.get(\"apiKey\"),",
-                          "        'Content-Type': 'application/json'",
-                          "    },",
-                          "    body: {",
-                          "        mode: 'raw',",
-                          "        raw: JSON.stringify({",
-                          "  \"name\": \"Weather assistant\",",
-                          "  \"config\": {",
-                          "            \"configurable\": {",
-                          "                \"type\": \"chatbot\",",
-                          "                \"agent_type\": \"GPT 4o Mini\",",
-                          "                \"system_message\": \"You are a helpful weather assistant.\",",
-                          "                \"tools\": [\"DDG Search\"],",
-                          "                \"llm_type\": \"GPT 4o Mini\"",
-                          "            }",
-                          "        },",
-                          "  \"user_id\": \"asdf\",",
-                          "  \"kwargs\": {",
-                          "            \"description\": \"An assistant for weather-related queries\"",
-                          "        },",
-                          "  \"public\": false",
-                          "})",
-                          "    }",
-                          "}, function (err, res) {",
-                          "    if (err) {",
-                          "        console.log(err);",
-                          "    } else {",
-                          "        const response = res.json();",
-                          "        pm.environment.set(\"assistantId\", response.id);",
-                          "    }",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    },
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(200);",
-                          "});",
-                          "",
-                          "pm.test(\"Response has valid JSON structure\", function () {",
-                          "    pm.response.to.be.json;",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "PATCH",
-                    "header": [
-                      {
-                        "key": "Content-Type",
-                        "value": "application/json"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"name\": \"Weather assistant updated\",\n  \"config\": {\n            \"configurable\": {\n                \"type\": \"chatbot\",\n                \"agent_type\": \"GPT 4o Mini\",\n                \"system_message\": \"You are a helpful weather assistant.\",\n                \"tools\": [\"DDG Search\"],\n                \"llm_type\": \"GPT 4o Mini\"\n            }\n        },\n  \"user_id\": \"asdf\",\n  \"kwargs\": {\n            \"description\": \"An assistant for weather-related queries\"\n        },\n  \"public\": false\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "assistants", "{{assistantId}}"]
-                    },
-                    "description": "Updates the details of a specific assistant by its ID."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "PATCH",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "assistants", ":assistant_id"],
-                          "variable": [
-                            {
-                              "key": "assistant_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 4o Mini\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "PATCH",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "assistants", ":assistant_id"],
-                          "variable": [
-                            {
-                              "key": "assistant_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Delete a specific assistant",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 204\", function () {",
-                          "    pm.response.to.have.status(204);",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    },
-                    {
-                      "listen": "prerequest",
-                      "script": {
-                        "exec": [
-                          "pm.variables.set(\"assistantId\", \"cd2a7145-6f36-4456-8fa9-e81be98a2409\")"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "DELETE",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "assistants", "{{assistantId}}"]
-                    },
-                    "description": "Deletes a specific assistant by its ID from the database."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "assistants", ":assistant_id"],
-                          "variable": [
-                            {
-                              "key": "assistant_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "No Content",
-                      "code": 204,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "assistants", ":assistant_id"],
-                          "variable": [
-                            {
-                              "key": "assistant_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "Retrieve all assistants",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});",
-                      "",
-                      "pm.test(\"Response has valid JSON structure\", function () {",
-                      "    pm.response.to.be.json;",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/assistants",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "assistants"]
-                },
-                "description": "Retrieves a list of all assistants."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/assistants",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "assistants"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 4o Mini\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 4o Mini\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  }\n]"
-                }
-              ]
-            },
-            {
-              "name": "Create a new assistant",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});",
-                      "",
-                      "pm.test(\"Response has valid JSON structure\", function () {",
-                      "    pm.response.to.be.json;",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"Weather assistant\",\n  \"config\": {\n            \"configurable\": {\n                \"type\": \"chatbot\",\n                \"agent_type\": \"GPT 4o Mini\",\n                \"system_message\": \"You are a helpful weather assistant.\",\n                \"tools\": [\"DDG Search\"],\n                \"llm_type\": \"GPT 4o Mini\"\n            }\n        },\n  \"kwargs\": {\n            \"description\": \"An assistant for weather-related queries\"\n        },\n  \"public\": false\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/assistants",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "assistants"]
-                },
-                "description": "Creates a new assistant with the specified details."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/assistants",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "assistants"]
-                    }
-                  },
-                  "status": "Created",
-                  "code": 201,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 4o Mini\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/assistants",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "assistants"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "rag",
-          "item": [
-            {
-              "name": "Ingest files to be indexed and queried.",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"files\": [\n    \"<uuid>\",\n    \"<uuid>\"\n  ],\n  \"purpose\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"document_processor\": {\n    \"summarize\": false,\n    \"encoder\": {\n      \"provider\": \"openai\",\n      \"encoder_model\": \"text-embedding-3-small\",\n      \"dimensions\": 1536\n    },\n    \"unstructured\": {\n      \"partition_strategy\": \"auto\",\n      \"hi_res_model_name\": \"detectron2_onnx\",\n      \"process_tables\": false\n    },\n    \"splitter\": {\n      \"name\": \"semantic\",\n      \"min_tokens\": 30,\n      \"max_tokens\": 800,\n      \"rolling_window_size\": 1,\n      \"prefix_titles\": true,\n      \"prefix_summary\": true\n    }\n  },\n  \"webhook_url\": \"<string>\"\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/rag/ingest",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "rag", "ingest"]
-                },
-                "description": "Upload files for ingesting using the advanced RAG system."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"files\": [\n    \"<uuid>\",\n    \"<uuid>\"\n  ],\n  \"purpose\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"document_processor\": {\n    \"summarize\": false,\n    \"encoder\": {\n      \"provider\": \"openai\",\n      \"encoder_model\": \"text-embedding-3-small\",\n      \"dimensions\": 1536\n    },\n    \"unstructured\": {\n      \"partition_strategy\": \"auto\",\n      \"hi_res_model_name\": \"detectron2_onnx\",\n      \"process_tables\": false\n    },\n    \"splitter\": {\n      \"name\": \"semantic\",\n      \"min_tokens\": 30,\n      \"max_tokens\": 800,\n      \"rolling_window_size\": 1,\n      \"prefix_titles\": true,\n      \"prefix_summary\": true\n    }\n  },\n  \"webhook_url\": \"<string>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/rag/ingest",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "rag", "ingest"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "\"<object>\""
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"files\": [\n    \"<uuid>\",\n    \"<uuid>\"\n  ],\n  \"purpose\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"document_processor\": {\n    \"summarize\": false,\n    \"encoder\": {\n      \"provider\": \"openai\",\n      \"encoder_model\": \"text-embedding-3-small\",\n      \"dimensions\": 1536\n    },\n    \"unstructured\": {\n      \"partition_strategy\": \"auto\",\n      \"hi_res_model_name\": \"detectron2_onnx\",\n      \"process_tables\": false\n    },\n    \"splitter\": {\n      \"name\": \"semantic\",\n      \"min_tokens\": 30,\n      \"max_tokens\": 800,\n      \"rolling_window_size\": 1,\n      \"prefix_titles\": true,\n      \"prefix_summary\": true\n    }\n  },\n  \"webhook_url\": \"<string>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/rag/ingest",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "rag", "ingest"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Query documents",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/rag/query",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "rag", "query"]
-                },
-                "description": "Query ingested documents using advanced RAG system with unstructured library. <br>"
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/rag/query",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "rag", "query"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": [\n    {\n      \"id\": \"<string>\",\n      \"document_id\": \"<string>\",\n      \"page_content\": \"<string>\",\n      \"file_id\": \"<string>\",\n      \"namespace\": \"<string>\",\n      \"source\": \"<string>\",\n      \"source_type\": \"<string>\",\n      \"chunk_index\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"purpose\": \"<string>\",\n      \"token_count\": \"<integer>\",\n      \"page_number\": \"<integer>\",\n      \"metadata\": \"<object>\",\n      \"dense_embedding\": [\n        \"<number>\",\n        \"<number>\"\n      ]\n    },\n    {\n      \"id\": \"<string>\",\n      \"document_id\": \"<string>\",\n      \"page_content\": \"<string>\",\n      \"file_id\": \"<string>\",\n      \"namespace\": \"<string>\",\n      \"source\": \"<string>\",\n      \"source_type\": \"<string>\",\n      \"chunk_index\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"purpose\": \"<string>\",\n      \"token_count\": \"<integer>\",\n      \"page_number\": \"<integer>\",\n      \"metadata\": \"<object>\",\n      \"dense_embedding\": [\n        \"<number>\",\n        \"<number>\"\n      ]\n    }\n  ]\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/rag/query",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "rag", "query"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Query Lc Retriever",
-              "request": {
-                "auth": {
-                  "type": "apikey",
-                  "apikey": [
-                    {
-                      "key": "key",
-                      "value": "X-API-KEY",
-                      "type": "string"
-                    },
-                    {
-                      "key": "value",
-                      "value": "{{apiKey}}",
-                      "type": "string"
-                    },
-                    {
-                      "key": "in",
-                      "value": "header",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/rag/query-lc-retriever",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "rag", "query-lc-retriever"]
-                }
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/rag/query-lc-retriever",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "rag", "query-lc-retriever"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/rag/query-lc-retriever",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "rag", "query-lc-retriever"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "files",
-          "item": [
-            {
-              "name": "{file_id}",
-              "item": [
-                {
-                  "name": "Retrieve file information",
-                  "event": [
-                    {
-                      "listen": "prerequest",
-                      "script": {
-                        "exec": [
-                          "pm.variables.set(\"fileId\", \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\")"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    },
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(200);",
-                          "});",
-                          "",
-                          "pm.test(\"Response has valid JSON structure\", function () {",
-                          "    pm.response.to.be.json;",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/files/{{fileId}}",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "files", "{{fileId}}"]
-                    },
-                    "description": "Retrieves information about a specific file by its ID."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/files/:file_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "files", ":file_id"],
-                          "variable": [
-                            {
-                              "key": "file_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"purpose\": \"<string>\",\n  \"filename\": \"<string>\",\n  \"bytes\": \"<integer>\",\n  \"mime_type\": \"<string>\",\n  \"source\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/files/:file_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "files", ":file_id"],
-                          "variable": [
-                            {
-                              "key": "file_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Delete a specific file",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/files/:file_id",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "files", ":file_id"],
-                      "variable": [
-                        {
-                          "key": "file_id",
-                          "value": "<uuid>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "Deletes a specific file by its ID from the database and file system. When a file is deleted, it is also removed from any assistants that may be using it and all associated embeddings are deleted from the vector store."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/files/:file_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "files", ":file_id"],
-                          "variable": [
-                            {
-                              "key": "file_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"file_id\": \"<uuid>\",\n  \"num_of_assistants\": \"<integer>\",\n  \"assistants\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"num_of_deleted_chunks\": \"<integer>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/files/:file_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "files", ":file_id"],
-                          "variable": [
-                            {
-                              "key": "file_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Retrieve the content of a specific file",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(200);",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    },
-                    {
-                      "listen": "prerequest",
-                      "script": {
-                        "exec": [
-                          "pm.variables.set(\"fileId\", \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\")"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/files/{{fileId}}/content",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "files", "{{fileId}}", "content"]
-                    },
-                    "description": "Retrieves the content of a specific file by its ID. Returns a downloadable file."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/files/:file_id/content",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "files", ":file_id", "content"],
-                          "variable": [
-                            {
-                              "key": "file_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "X-API-KEY",
-                            "value": "<API Key>",
-                            "description": "Added as a part of security scheme: apikey"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/files/:file_id/content",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "files", ":file_id", "content"],
-                          "variable": [
-                            {
-                              "key": "file_id",
-                              "value": "<uuid>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "Upload a file",
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "const uuid = require('uuid');",
-                      "",
-                      "pm.variables.set('file_name', uuid.v4());"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});",
-                      "",
-                      "pm.test(\"Response has valid JSON structure\", function () {",
-                      "    pm.response.to.be.json;",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "multipart/form-data"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "formdata",
-                  "formdata": [
-                    {
-                      "key": "file",
-                      "description": "(Required) The file to upload.",
-                      "type": "file",
-                      "src": "postman-cloud:///1ef379dd-c051-4b10-98ce-f78ec7887dbe"
-                    },
-                    {
-                      "key": "purpose",
-                      "value": "assistants",
-                      "description": "(Required) The purpose of the file: 'assistants', 'threads', or 'personas'.",
-                      "type": "text"
-                    },
-                    {
-                      "key": "filename",
-                      "value": "{{file_name}}.pdf",
-                      "description": "The preferred name for the file.",
-                      "type": "text"
-                    },
-                    {
-                      "key": "kwargs",
-                      "value": "{}",
-                      "description": "Any additonal metadata to include for this file. This should be a JSON string.",
-                      "type": "text"
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/files",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "files"]
-                },
-                "description": "Uploads a file that can be used across various endpoints. <br> NOTE: MUST INCLUDE `user_id`"
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "formdata",
-                      "formdata": [
-                        {
-                          "key": "file",
-                          "value": "<binary>",
-                          "description": "(Required) The file to upload.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "purpose",
-                          "value": "<string>",
-                          "description": "(Required) The purpose of the file: 'assistants', 'threads', or 'personas'.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "user_id",
-                          "value": "<string>",
-                          "description": "(Required) The user id of the file owner.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "filename",
-                          "value": "<string>",
-                          "description": "The preferred name for the file.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "kwargs",
-                          "value": "<string>",
-                          "description": "Any additonal metadata to include for this file. This should be a JSON string.",
-                          "type": "text"
-                        }
-                      ]
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/files",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "files"]
-                    }
-                  },
-                  "status": "Created",
-                  "code": 201,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"purpose\": \"<string>\",\n  \"filename\": \"<string>\",\n  \"bytes\": \"<integer>\",\n  \"mime_type\": \"<string>\",\n  \"source\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "formdata",
-                      "formdata": [
-                        {
-                          "key": "file",
-                          "value": "<binary>",
-                          "description": "(Required) The file to upload.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "purpose",
-                          "value": "<string>",
-                          "description": "(Required) The purpose of the file: 'assistants', 'threads', or 'personas'.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "user_id",
-                          "value": "<string>",
-                          "description": "(Required) The user id of the file owner.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "filename",
-                          "value": "<string>",
-                          "description": "The preferred name for the file.",
-                          "type": "text"
-                        },
-                        {
-                          "key": "kwargs",
-                          "value": "<string>",
-                          "description": "Any additonal metadata to include for this file. This should be a JSON string.",
-                          "type": "text"
-                        }
-                      ]
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/files",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "files"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Retrieve files",
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [""],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});",
-                      "",
-                      "pm.test(\"Response has valid JSON structure\", function () {",
-                      "    pm.response.to.be.json;",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/files?user_id={{userId}}",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "files"],
-                  "query": [
-                    {
-                      "key": "user_id",
-                      "value": "{{userId}}"
-                    }
-                  ]
-                },
-                "description": "Retrieves a list of files."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/files?user_id=<string>&purpose=<string>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "files"],
-                      "query": [
-                        {
-                          "key": "user_id",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "purpose",
-                          "value": "<string>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  }\n]"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "X-API-KEY",
-                        "value": "<API Key>",
-                        "description": "Added as a part of security scheme: apikey"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/files?user_id=<string>&purpose=<string>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "files"],
-                      "query": [
-                        {
-                          "key": "user_id",
-                          "value": "<string>"
-                        },
-                        {
-                          "key": "purpose",
-                          "value": "<string>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "auth",
-          "item": [
-            {
-              "name": "Get enabled authentication strategies",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/auth/auth_strategies",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "auth", "auth_strategies"]
-                },
-                "description": "Returns a list of enabled authentication strategies."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "http://localhost:9000/api/v1/auth/auth_strategies",
-                      "protocol": "http",
-                      "host": ["localhost"],
-                      "port": "9000",
-                      "path": ["api", "v1", "auth", "auth_strategies"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "[\n  {\n    \"strategy\": \"<string>\",\n    \"client_id\": \"<string>\",\n    \"authorization_endpoint\": \"<string>\",\n    \"pkce_enabled\": \"<boolean>\"\n  },\n  {\n    \"strategy\": \"<string>\",\n    \"client_id\": \"<string>\",\n    \"authorization_endpoint\": \"<string>\",\n    \"pkce_enabled\": \"<boolean>\"\n  }\n]"
-                }
-              ]
-            },
-            {
-              "name": "Login",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"strategy\": \"<string>\",\n  \"payload\": {\n    \"qui_d7e\": \"<string>\",\n    \"mollit4a1\": \"<string>\",\n    \"reprehenderit9_2\": \"<string>\",\n    \"est_8c\": \"<string>\"\n  }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/auth/login",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "auth", "login"]
-                },
-                "description": "Logs user in, performing auth according to auth strategy."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"strategy\": \"<string>\",\n  \"payload\": {\n    \"qui_d7e\": \"<string>\",\n    \"mollit4a1\": \"<string>\",\n    \"reprehenderit9_2\": \"<string>\",\n    \"est_8c\": \"<string>\"\n  }\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "http://localhost:9000/api/v1/auth/login",
-                      "protocol": "http",
-                      "host": ["localhost"],
-                      "port": "9000",
-                      "path": ["api", "v1", "auth", "login"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"token\": \"<string>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"strategy\": \"<string>\",\n  \"payload\": {\n    \"qui_d7e\": \"<string>\",\n    \"mollit4a1\": \"<string>\",\n    \"reprehenderit9_2\": \"<string>\",\n    \"est_8c\": \"<string>\"\n  }\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/auth/login",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "auth", "login"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Authorize",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/auth/:strategy/auth?code=<string>",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "auth", ":strategy", "auth"],
-                  "query": [
-                    {
-                      "key": "code",
-                      "value": "<string>",
-                      "description": "Code returned from OAuth provider for OIDC token exchange"
-                    }
-                  ],
-                  "variable": [
-                    {
-                      "key": "strategy",
-                      "value": "<string>",
-                      "description": "(Required) "
-                    }
-                  ]
-                },
-                "description": "Callback authorization endpoint used for OAuth providers after authenticating on the provider's login screen."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "http://localhost:9000/api/v1/auth/:strategy/auth",
-                      "protocol": "http",
-                      "host": ["localhost"],
-                      "port": "9000",
-                      "path": ["api", "v1", "auth", ":strategy", "auth"],
-                      "variable": [
-                        {
-                          "key": "strategy",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"token\": \"<string>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/auth/:strategy/auth",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "auth", ":strategy", "auth"],
-                      "variable": [
-                        {
-                          "key": "strategy",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Logout",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/auth/logout",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "auth", "logout"]
-                },
-                "description": "Logs user out, adding the given JWT token to the blacklist."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "http://localhost:9000/api/v1/auth/logout",
-                      "protocol": "http",
-                      "host": ["localhost"],
-                      "port": "9000",
-                      "path": ["api", "v1", "auth", "logout"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{}"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "admin/users",
-          "item": [
-            {
-              "name": "{user_id}",
-              "item": [
-                {
-                  "name": "Retrieve a specific user",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(200);",
-                          "});",
-                          "",
-                          "pm.test(\"Response has valid JSON structure\", function () {",
-                          "    pm.response.to.be.json;",
-                          "    const responseJson = pm.response.json();",
-                          "    pm.expect(responseJson).to.have.property('user_id');",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "admin", "users", ":user_id"],
-                      "variable": [
-                        {
-                          "key": "user_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "GET endpoint at `/users/{user_id}` for fetching details of a specific user using its user_id.\n        USAGE: Admins can use this endpoint to retrieve details of a specific user.\n        TODO: Add access control for this endpoint."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "admin", "users", ":user_id"],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "admin", "users", ":user_id"],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Update a specific user ",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(200);",
-                          "});",
-                          "",
-                          "pm.test(\"Response has valid JSON structure\", function () {",
-                          "    pm.response.to.be.json;",
-                          "    const responseJson = pm.response.json();",
-                          "    pm.expect(responseJson).to.have.property('user_id');",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "PATCH",
-                    "header": [
-                      {
-                        "key": "Content-Type",
-                        "value": "application/json"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "admin", "users", ":user_id"],
-                      "variable": [
-                        {
-                          "key": "user_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "PATCH endpoint at `/{user_id}` for updating the details of a specific user.\n        USAGE: Admins can use this endpoint to update the details of a specific user.\n        TODO: Add access control for this endpoint."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "PATCH",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "admin", "users", ":user_id"],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "PATCH",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "body": {
-                          "mode": "raw",
-                          "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
-                          "options": {
-                            "raw": {
-                              "language": "json"
-                            }
-                          }
-                        },
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "admin", "users", ":user_id"],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Retrieve user assistants",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users/:user_id/assistants",
-                      "host": ["{{baseUrl}}"],
-                      "path": [
-                        "api",
-                        "v1",
-                        "admin",
-                        "users",
-                        ":user_id",
-                        "assistants"
-                      ],
-                      "variable": [
-                        {
-                          "key": "user_id",
-                          "value": "<string>",
-                          "description": "Required"
-                        }
-                      ]
-                    },
-                    "description": "Retrieves a list of the user's assistants."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/assistants",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "admin", "users", "assistants"]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 4o Mini\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 4o Mini\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  }\n]"
-                    }
-                  ]
-                },
-                {
-                  "name": "Delete a specific user ",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(204);",
-                          "});",
-                          ""
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "DELETE",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "admin", "users", ":user_id"],
-                      "variable": [
-                        {
-                          "key": "user_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "DELETE endpoint at `/users/{user_id}` for removing a specific user using its `user_id`.\n                USAGE: Admins can use this endpoint to delete a specific user.\n                TODO: Add access control for this endpoint."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "admin", "users", ":user_id"],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "No Content",
-                      "code": 204,
-                      "_postman_previewlanguage": "text",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": ""
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "DELETE",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
-                          "host": ["{{baseUrl}}"],
-                          "path": ["api", "v1", "admin", "users", ":user_id"],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                },
-                {
-                  "name": "Retrieve threads by user ",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [
-                          "pm.test(\"Status code is 200\", function () {",
-                          "    pm.response.to.have.status(200);",
-                          "});",
-                          "",
-                          "pm.test(\"Response has valid JSON structure\", function () {",
-                          "    pm.response.to.be.json;",
-                          "});"
-                        ],
-                        "type": "text/javascript",
-                        "packages": {}
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users/:user_id/threads?grouped=<boolean>&timezoneOffset=<integer>",
-                      "host": ["{{baseUrl}}"],
-                      "path": [
-                        "api",
-                        "v1",
-                        "admin",
-                        "users",
-                        ":user_id",
-                        "threads"
-                      ],
-                      "query": [
-                        {
-                          "key": "grouped",
-                          "value": "<boolean>"
-                        },
-                        {
-                          "key": "timezoneOffset",
-                          "value": "<integer>"
-                        }
-                      ],
-                      "variable": [
-                        {
-                          "key": "user_id",
-                          "value": "<string>",
-                          "description": "(Required) "
-                        }
-                      ]
-                    },
-                    "description": "GET endpoint at `/users/{user_id}/threads` for fetching all threads associated with a specific user using its id. <br>\n                USAGE: Admins can use this endpoint to retrieve all threads associated with a specific user.\n                TODO: Add access control for this endpoint."
-                  },
-                  "response": [
-                    {
-                      "name": "Successful Response",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id/threads?grouped=<boolean>&timezoneOffset=<integer>",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "admin",
-                            "users",
-                            ":user_id",
-                            "threads"
-                          ],
-                          "query": [
-                            {
-                              "key": "grouped",
-                              "value": "<boolean>"
-                            },
-                            {
-                              "key": "timezoneOffset",
-                              "value": "<integer>"
-                            }
-                          ],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "OK",
-                      "code": 200,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
-                    },
-                    {
-                      "name": "Validation Error",
-                      "originalRequest": {
-                        "method": "GET",
-                        "header": [
-                          {
-                            "key": "Authorization",
-                            "value": "Bearer <token>",
-                            "description": "Added as a part of security scheme: bearer"
-                          },
-                          {
-                            "key": "Accept",
-                            "value": "application/json"
-                          }
-                        ],
-                        "url": {
-                          "raw": "{{baseUrl}}/api/v1/admin/users/:user_id/threads?grouped=<boolean>&timezoneOffset=<integer>",
-                          "host": ["{{baseUrl}}"],
-                          "path": [
-                            "api",
-                            "v1",
-                            "admin",
-                            "users",
-                            ":user_id",
-                            "threads"
-                          ],
-                          "query": [
-                            {
-                              "key": "grouped",
-                              "value": "<boolean>"
-                            },
-                            {
-                              "key": "timezoneOffset",
-                              "value": "<integer>"
-                            }
-                          ],
-                          "variable": [
-                            {
-                              "key": "user_id",
-                              "value": "<string>",
-                              "description": "(Required) "
-                            }
-                          ]
-                        }
-                      },
-                      "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                      "code": 422,
-                      "_postman_previewlanguage": "json",
-                      "header": [
-                        {
-                          "key": "Content-Type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "cookie": [],
-                      "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "List all users ",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});",
-                      "",
-                      "pm.test(\"Response has valid JSON structure\", function () {",
-                      "    pm.response.to.be.json;",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "bearer",
-                  "bearer": [
-                    {
-                      "key": "token",
-                      "value": "{{bearerToken}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/admin/users",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "admin", "users"]
-                },
-                "description": "GET endpoint at `/users` for listing all users.\n                TODO: Add access control for this endpoint."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "admin", "users"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "[\n  {\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"email\": \"<string>\",\n    \"first_name\": \"<string>\",\n    \"last_name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"email\": \"<string>\",\n    \"first_name\": \"<string>\",\n    \"last_name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
-                }
-              ]
-            },
-            {
-              "name": "Create a new user",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});",
-                      "",
-                      "pm.test(\"Response has valid JSON structure\", function () {",
-                      "    pm.response.to.be.json;",
-                      "    const responseJson = pm.response.json();",
-                      "    pm.expect(responseJson).to.have.property('user_id');",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"user_id\": \"<string>\"\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/admin/users",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "admin", "users"]
-                },
-                "description": "POST endpoint at `/users` for creating a new user.\n                If `user_id` is not present, the database will auto-generate a new UUID for the field.\n                This is intended to allow for internal users to be correlated with external systems while not exposing the internal database record id for the user.\n                TODO: Add access control for this endpoint."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\",\n  \"user_id\": \"<string>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "admin", "users"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\",\n  \"user_id\": \"<string>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "admin", "users"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Retrieve all threads",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/admin/users/threads",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "admin", "users", "threads"]
-                },
-                "description": "Retrieves a list of all threads in the database.\n                Should be used as an admin operation. <br>\n                TODO: Add access control for this endpoint."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/admin/users/threads",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "admin", "users", "threads"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "users/me",
-          "item": [
-            {
-              "name": "Retrieve a specific user ",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/users/me",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "users", "me"]
-                },
-                "description": "GET endpoint to fetch details of the logged-in user.\n        USAGE: Admins can use this endpoint to retrieve details of a specific user.\n        TODO: Add RBAC for this endpoint."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/users/me",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "users", "me"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                }
-              ]
-            },
-            {
-              "name": "Delete a specific user ",
-              "request": {
-                "method": "DELETE",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/users/me",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "users", "me"]
-                },
-                "description": "DELETE endpoint for removing the logged-in user from the system.\n                This will do a cascade delete on all threads and messages, but will not\n                effect assistants created by the user."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "DELETE",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/users/me",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "users", "me"]
-                    }
-                  },
-                  "status": "No Content",
-                  "code": 204,
-                  "_postman_previewlanguage": "text",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "text/plain"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": ""
-                }
-              ]
-            },
-            {
-              "name": "Update a specific user ",
-              "request": {
-                "method": "PATCH",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/users/me",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "users", "me"]
-                },
-                "description": "PATCH endpoint for updating the details of the logged-in user."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "PATCH",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/users/me",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "users", "me"]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "PATCH",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/users/me",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "users", "me"]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            },
-            {
-              "name": "Retrieve threads by user ",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/users/me/threads?grouped=<boolean>&timezoneOffset=<integer>",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "users", "me", "threads"],
-                  "query": [
-                    {
-                      "key": "grouped",
-                      "value": "<boolean>",
-                      "description": "Group threads into date categories (eg. Today, Yesterday, etc.)"
-                    },
-                    {
-                      "key": "timezoneOffset",
-                      "value": "<integer>",
-                      "description": "Timezone offset in minutes from UTC"
-                    }
-                  ]
-                },
-                "description": "GET endpoint for fetching all threads associated with the logged-in user."
-              },
-              "response": [
-                {
-                  "name": "Successful Response",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/users/me/threads?grouped=<boolean>&timezoneOffset=<integer>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "users", "me", "threads"],
-                      "query": [
-                        {
-                          "key": "grouped",
-                          "value": "<boolean>"
-                        },
-                        {
-                          "key": "timezoneOffset",
-                          "value": "<integer>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "OK",
-                  "code": 200,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
-                },
-                {
-                  "name": "Validation Error",
-                  "originalRequest": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Bearer <token>",
-                        "description": "Added as a part of security scheme: bearer"
-                      },
-                      {
-                        "key": "Accept",
-                        "value": "application/json"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}/api/v1/users/me/threads?grouped=<boolean>&timezoneOffset=<integer>",
-                      "host": ["{{baseUrl}}"],
-                      "path": ["api", "v1", "users", "me", "threads"],
-                      "query": [
-                        {
-                          "key": "grouped",
-                          "value": "<boolean>"
-                        },
-                        {
-                          "key": "timezoneOffset",
-                          "value": "<integer>"
-                        }
-                      ]
-                    }
-                  },
-                  "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
-                  "code": 422,
-                  "_postman_previewlanguage": "json",
-                  "header": [
-                    {
-                      "key": "Content-Type",
-                      "value": "application/json"
-                    }
-                  ],
-                  "cookie": [],
-                  "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Health Check",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Accept",
-                "value": "application/json"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/health_check",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "health_check"]
-            }
-          },
-          "response": [
-            {
-              "name": "Successful Response",
-              "originalRequest": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/v1/health_check",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["api", "v1", "health_check"]
-                }
-              },
-              "status": "OK",
-              "code": 200,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "cookie": [],
-              "body": "{}"
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "packages": {},
-        "exec": [""]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "packages": {},
-        "exec": [""]
-      }
-    }
-  ],
-  "variable": [
-    {
-      "key": "baseUrl",
-      "value": "http://localhost:9000",
-      "type": "string"
-    }
-  ]
+	"info": {
+		"_postman_id": "711b1f9f-6bcb-4650-b362-c7bdcc0e74eb",
+		"name": "PersonaFlow",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "16936331",
+		"_collection_link": "https://winter-resonance-224282.postman.co/workspace/PersonaFlow~5a05c830-9309-4e81-bbbb-50425c42988f/collection/16936331-711b1f9f-6bcb-4650-b362-c7bdcc0e74eb?action=share&source=collection_link&creator=16936331"
+	},
+	"item": [
+		{
+			"name": "api/v1",
+			"item": [
+				{
+					"name": "runs",
+					"item": [
+						{
+							"name": "Create a run",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/runs",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"runs"
+									]
+								},
+								"description": "Create a run to be processed by the LLM."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "\"<object>\""
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Stream an LLM run.",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/runs/stream",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"runs",
+										"stream"
+									]
+								},
+								"description": "Endpoint to stream an LLM response. If the thread_id is not provided, a new thread will be created as long as the assistant_id is included. <br>\n                Note that the input should be a list of messages in the format: <br>\n                content: string <br>\n                role: string <br>\n                additional_kwargs: dict <br>\n                example: bool <br>"
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs/stream",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs",
+												"stream"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"user_id\": \"<string>\",\n  \"input\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"assistant_id\": \"<string>\",\n  \"thread_id\": \"<string>\",\n  \"config\": {\n    \"tags\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"metadata\": \"<object>\",\n    \"run_name\": \"<string>\",\n    \"max_concurrency\": \"<integer>\",\n    \"recursion_limit\": \"<integer>\",\n    \"configurable\": \"<object>\",\n    \"run_id\": \"<uuid>\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs/stream",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs",
+												"stream"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Return the input schema of the runnable.",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/runs/input_schema",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"runs",
+										"input_schema"
+									]
+								},
+								"description": "Return the input schema of the runnable."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs/input_schema",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs",
+												"input_schema"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "\"<object>\""
+								}
+							]
+						},
+						{
+							"name": "Return the output schema of the runnable.",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/runs/output_schema",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"runs",
+										"output_schema"
+									]
+								},
+								"description": "Return the output schema of the runnable."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs/output_schema",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs",
+												"output_schema"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "\"<object>\""
+								}
+							]
+						},
+						{
+							"name": "Return the config schema of the runnable.",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/runs/config_schema",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"runs",
+										"config_schema"
+									]
+								},
+								"description": "Return the config schema of the runnable."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs/config_schema",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs",
+												"config_schema"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "\"<object>\""
+								}
+							]
+						},
+						{
+							"name": "Generate a title to name the thread.",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"thread_id\": \"<string>\",\n  \"history\": [\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/runs/title",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"runs",
+										"title"
+									]
+								},
+								"description": "Generates a title for the conversation by sending a list of interactions to the model."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"thread_id\": \"<string>\",\n  \"history\": [\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs/title",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs",
+												"title"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"thread_id\": \"<string>\",\n  \"history\": [\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"content\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/runs/title",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"runs",
+												"title"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "threads",
+					"item": [
+						{
+							"name": "{thread_id}",
+							"item": [
+								{
+									"name": "state",
+									"item": [
+										{
+											"name": "Retrieve thread state",
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id",
+														"state"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Retrieves the state of a thread identified by its ID."
+											},
+											"response": [
+												{
+													"name": "Successful Response",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"threads",
+																":thread_id",
+																"state"
+															],
+															"variable": [
+																{
+																	"key": "thread_id",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"name": "Validation Error",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"threads",
+																":thread_id",
+																"state"
+															],
+															"variable": [
+																{
+																	"key": "thread_id",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+													"code": 422,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+												}
+											]
+										},
+										{
+											"name": "Add thread state",
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"values\": [\n    {\n      \"value\": \"<Error: Schema not found>\"\n    },\n    {\n      \"value\": \"<Error: Schema not found>\"\n    }\n  ],\n  \"config\": \"<object>\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id",
+														"state"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Adds the state of a thread identified by its ID."
+											},
+											"response": [
+												{
+													"name": "Successful Response",
+													"originalRequest": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"values\": [\n    {\n      \"value\": \"<Error: Schema not found>\"\n    },\n    {\n      \"value\": \"<Error: Schema not found>\"\n    }\n  ],\n  \"config\": \"<object>\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"threads",
+																":thread_id",
+																"state"
+															],
+															"variable": [
+																{
+																	"key": "thread_id",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"name": "Validation Error",
+													"originalRequest": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"values\": [\n    {\n      \"value\": \"<Error: Schema not found>\"\n    },\n    {\n      \"value\": \"<Error: Schema not found>\"\n    }\n  ],\n  \"config\": \"<object>\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/threads/:thread_id/state",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"threads",
+																":thread_id",
+																"state"
+															],
+															"variable": [
+																{
+																	"key": "thread_id",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+													"code": 422,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "Retrieve a specific thread",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"threads",
+												":thread_id"
+											],
+											"variable": [
+												{
+													"key": "thread_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "Retrieves detailed information about a thread identified by its ID."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Update a specific thread",
+									"request": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"threads",
+												":thread_id"
+											],
+											"variable": [
+												{
+													"key": "thread_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "Updates the information of a thread identified by its ID."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete a specific thread",
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"threads",
+												":thread_id"
+											],
+											"variable": [
+												{
+													"key": "thread_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "Deletes a thread identified by its ID from the database."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Get thread history",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/threads/:thread_id/history",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"threads",
+												":thread_id",
+												"history"
+											],
+											"variable": [
+												{
+													"key": "thread_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "Gets the history of the thread identified by its ID."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id/history",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id",
+														"history"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/threads/:thread_id/history",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"threads",
+														":thread_id",
+														"history"
+													],
+													"variable": [
+														{
+															"key": "thread_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								}
+							]
+						},
+						{
+							"name": "Create a new thread",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/threads",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"threads"
+									]
+								},
+								"description": "Creates a new thread with the provided information. This can optionally be obtained from the api_key. If it is not set in the request, it will attempt to get it from the api_key."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/threads",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"threads"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"assistant_id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"assistant_id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/threads",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"threads"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "assistants",
+					"item": [
+						{
+							"name": "{assistant_id}",
+							"item": [
+								{
+									"name": "files",
+									"item": [
+										{
+											"name": "Add an uploaded file to an assistant for RAG.",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"pm.sendRequest({",
+															"    url: pm.environment.get(\"baseUrl\") + \"/api/v1/assistants\",",
+															"    method: 'POST',",
+															"    header: {",
+															"        'X-API-KEY': pm.environment.get(\"apiKey\"),",
+															"        'Content-Type': 'application/json'",
+															"    },",
+															"    body: {",
+															"        mode: 'raw',",
+															"        raw: JSON.stringify({",
+															"  \"name\": \"Weather assistant\",",
+															"  \"config\": {",
+															"            \"configurable\": {",
+															"                \"type\": \"chatbot\",",
+															"                \"agent_type\": \"GPT 3.5 Turbo\",",
+															"                \"system_message\": \"You are a helpful weather assistant.\",",
+															"                \"tools\": [\"DDG Search\"],",
+															"                \"llm_type\": \"GPT 3.5 Turbo\"",
+															"            }",
+															"        },",
+															"  \"kwargs\": {",
+															"            \"description\": \"An assistant for weather-related queries\"",
+															"        },",
+															"  \"public\": false",
+															"})",
+															"    }",
+															"}, function (err, res) {",
+															"    if (err) {",
+															"        console.log(err);",
+															"    } else {",
+															"        const response = res.json();",
+															"        pm.environment.set(\"assistantId\", response.id);",
+															"    }",
+															"});"
+														],
+														"type": "text/javascript",
+														"packages": {}
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"file_id\": \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}/files",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														"{{assistantId}}",
+														"files"
+													]
+												},
+												"description": "Convenience method to add an uploaded file to an assistant for RAG ingestion and retrieval"
+											},
+											"response": [
+												{
+													"name": "Successful Response",
+													"originalRequest": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-API-KEY",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"file_id\": \"<string>\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"assistants",
+																":assistant_id",
+																"files"
+															],
+															"variable": [
+																{
+																	"key": "assistant_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"file_id\": \"<string>\",\n  \"assistant_id\": \"<string>\"\n}"
+												},
+												{
+													"name": "Validation Error",
+													"originalRequest": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-API-KEY",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"file_id\": \"<string>\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"assistants",
+																":assistant_id",
+																"files"
+															],
+															"variable": [
+																{
+																	"key": "assistant_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+													"code": 422,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+												}
+											]
+										},
+										{
+											"name": "Retrieve file information for all files associated with an assistant",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Response has valid JSON structure\", function () {",
+															"    pm.response.to.be.json;",
+															"});"
+														],
+														"type": "text/javascript",
+														"packages": {}
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"pm.variables.set(\"assistantId\", \"36395fdd-b0e3-4d4f-b9e4-38737cc6cccd\")"
+														],
+														"type": "text/javascript",
+														"packages": {}
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}/files",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														"{{assistantId}}",
+														"files"
+													]
+												},
+												"description": "Returns a list of file objects for all files associated with an assistant."
+											},
+											"response": [
+												{
+													"name": "Successful Response",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-API-KEY",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files?limit=20&order=desc&before=<dateTime>&after=<dateTime>",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"assistants",
+																":assistant_id",
+																"files"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "20"
+																},
+																{
+																	"key": "order",
+																	"value": "desc"
+																},
+																{
+																	"key": "before",
+																	"value": "<dateTime>"
+																},
+																{
+																	"key": "after",
+																	"value": "<dateTime>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "assistant_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  }\n]"
+												},
+												{
+													"name": "Validation Error",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-API-KEY",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files?limit=20&order=desc&before=<dateTime>&after=<dateTime>",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"assistants",
+																":assistant_id",
+																"files"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "20"
+																},
+																{
+																	"key": "order",
+																	"value": "desc"
+																},
+																{
+																	"key": "before",
+																	"value": "<dateTime>"
+																},
+																{
+																	"key": "after",
+																	"value": "<dateTime>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "assistant_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+													"code": 422,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+												}
+											]
+										},
+										{
+											"name": "Remove a file from an assistant",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"pm.variables.set(\"assistantId\", \"36395fdd-b0e3-4d4f-b9e4-38737cc6cccd\")",
+															"pm.variables.set(\"fileId\", \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\")"
+														],
+														"type": "text/javascript",
+														"packages": {}
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}/files/{{fileId}}",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														"{{assistantId}}",
+														"files",
+														"{{fileId}}"
+													]
+												},
+												"description": "Removes a file from an assistant by its ID. This also deletes the corresponding documents from the vector store."
+											},
+											"response": [
+												{
+													"name": "Successful Response",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-API-KEY",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files/:file_id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"assistants",
+																":assistant_id",
+																"files",
+																":file_id"
+															],
+															"variable": [
+																{
+																	"key": "assistant_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																},
+																{
+																	"key": "file_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 3.5 Turbo\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
+												},
+												{
+													"name": "Validation Error",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-API-KEY",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id/files/:file_id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"api",
+																"v1",
+																"assistants",
+																":assistant_id",
+																"files",
+																":file_id"
+															],
+															"variable": [
+																{
+																	"key": "assistant_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																},
+																{
+																	"key": "file_id",
+																	"value": "<uuid>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+													"code": 422,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "Retrieve a specific assistant",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.sendRequest({",
+													"    url: pm.environment.get(\"baseUrl\") + \"/api/v1/assistants\",",
+													"    method: 'POST',",
+													"    header: {",
+													"        'X-API-KEY': pm.environment.get(\"apiKey\"),",
+													"        'Content-Type': 'application/json'",
+													"    },",
+													"    body: {",
+													"        mode: 'raw',",
+													"        raw: JSON.stringify({",
+													"  \"name\": \"Weather assistant\",",
+													"  \"config\": {",
+													"            \"configurable\": {",
+													"                \"type\": \"chatbot\",",
+													"                \"agent_type\": \"GPT 3.5 Turbo\",",
+													"                \"system_message\": \"You are a helpful weather assistant.\",",
+													"                \"tools\": [\"DDG Search\"],",
+													"                \"llm_type\": \"GPT 3.5 Turbo\"",
+													"            }",
+													"        },",
+													"  \"user_id\": \"asdf\",",
+													"  \"kwargs\": {",
+													"            \"description\": \"An assistant for weather-related queries\"",
+													"        },",
+													"  \"public\": false",
+													"})",
+													"    }",
+													"}, function (err, res) {",
+													"    if (err) {",
+													"        console.log(err);",
+													"    } else {",
+													"        const response = res.json();",
+													"        pm.environment.set(\"assistantId\", response.id);",
+													"    }",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response has valid JSON structure\", function () {",
+													"    pm.response.to.be.json;",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"assistants",
+												"{{assistantId}}"
+											]
+										},
+										"description": "Retrieves detailed information about a specific assistant by its ID."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														":assistant_id"
+													],
+													"variable": [
+														{
+															"key": "assistant_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 3.5 Turbo\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														":assistant_id"
+													],
+													"variable": [
+														{
+															"key": "assistant_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Update a specific assistant",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.sendRequest({",
+													"    url: pm.environment.get(\"baseUrl\") + \"/api/v1/assistants\",",
+													"    method: 'POST',",
+													"    header: {",
+													"        'X-API-KEY': pm.environment.get(\"apiKey\"),",
+													"        'Content-Type': 'application/json'",
+													"    },",
+													"    body: {",
+													"        mode: 'raw',",
+													"        raw: JSON.stringify({",
+													"  \"name\": \"Weather assistant\",",
+													"  \"config\": {",
+													"            \"configurable\": {",
+													"                \"type\": \"chatbot\",",
+													"                \"agent_type\": \"GPT 3.5 Turbo\",",
+													"                \"system_message\": \"You are a helpful weather assistant.\",",
+													"                \"tools\": [\"DDG Search\"],",
+													"                \"llm_type\": \"GPT 3.5 Turbo\"",
+													"            }",
+													"        },",
+													"  \"user_id\": \"asdf\",",
+													"  \"kwargs\": {",
+													"            \"description\": \"An assistant for weather-related queries\"",
+													"        },",
+													"  \"public\": false",
+													"})",
+													"    }",
+													"}, function (err, res) {",
+													"    if (err) {",
+													"        console.log(err);",
+													"    } else {",
+													"        const response = res.json();",
+													"        pm.environment.set(\"assistantId\", response.id);",
+													"    }",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response has valid JSON structure\", function () {",
+													"    pm.response.to.be.json;",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"name\": \"Weather assistant updated\",\n  \"config\": {\n            \"configurable\": {\n                \"type\": \"chatbot\",\n                \"agent_type\": \"GPT 3.5 Turbo\",\n                \"system_message\": \"You are a helpful weather assistant.\",\n                \"tools\": [\"DDG Search\"],\n                \"llm_type\": \"GPT 3.5 Turbo\"\n            }\n        },\n  \"user_id\": \"asdf\",\n  \"kwargs\": {\n            \"description\": \"An assistant for weather-related queries\"\n        },\n  \"public\": false\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"assistants",
+												"{{assistantId}}"
+											]
+										},
+										"description": "Updates the details of a specific assistant by its ID."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														":assistant_id"
+													],
+													"variable": [
+														{
+															"key": "assistant_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 3.5 Turbo\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														":assistant_id"
+													],
+													"variable": [
+														{
+															"key": "assistant_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete a specific assistant",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"assistantId\", \"cd2a7145-6f36-4456-8fa9-e81be98a2409\")"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/assistants/{{assistantId}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"assistants",
+												"{{assistantId}}"
+											]
+										},
+										"description": "Deletes a specific assistant by its ID from the database."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														":assistant_id"
+													],
+													"variable": [
+														{
+															"key": "assistant_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/assistants/:assistant_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"assistants",
+														":assistant_id"
+													],
+													"variable": [
+														{
+															"key": "assistant_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								}
+							]
+						},
+						{
+							"name": "Retrieve all assistants",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Response has valid JSON structure\", function () {",
+											"    pm.response.to.be.json;",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/assistants",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"assistants"
+									]
+								},
+								"description": "Retrieves a list of all assistants."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/assistants",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"assistants"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 3.5 Turbo\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 3.5 Turbo\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  }\n]"
+								}
+							]
+						},
+						{
+							"name": "Create a new assistant",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"Response has valid JSON structure\", function () {",
+											"    pm.response.to.be.json;",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"Weather assistant\",\n  \"config\": {\n            \"configurable\": {\n                \"type\": \"chatbot\",\n                \"agent_type\": \"GPT 3.5 Turbo\",\n                \"system_message\": \"You are a helpful weather assistant.\",\n                \"tools\": [\"DDG Search\"],\n                \"llm_type\": \"GPT 3.5 Turbo\"\n            }\n        },\n  \"kwargs\": {\n            \"description\": \"An assistant for weather-related queries\"\n        },\n  \"public\": false\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/assistants",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"assistants"
+									]
+								},
+								"description": "Creates a new assistant with the specified details."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/assistants",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"assistants"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"<uuid>\",\n  \"name\": \"<string>\",\n  \"config\": {\n    \"configurable\": {\n      \"type\": \"agent\",\n      \"agent_type\": \"GPT 3.5 Turbo\",\n      \"interrupt_before_action\": \"<boolean>\",\n      \"retrieval_description\": \"<string>\",\n      \"system_message\": \"<string>\",\n      \"tools\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"llm_type\": \"<string>\"\n    }\n  },\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"name\": \"<string>\",\n  \"config\": \"<object>\",\n  \"user_id\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"file_ids\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"public\": \"<boolean>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/assistants",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"assistants"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "rag",
+					"item": [
+						{
+							"name": "Ingest files to be indexed and queried.",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"files\": [\n    \"<uuid>\",\n    \"<uuid>\"\n  ],\n  \"purpose\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"document_processor\": {\n    \"summarize\": false,\n    \"encoder\": {\n      \"provider\": \"openai\",\n      \"encoder_model\": \"text-embedding-3-small\",\n      \"dimensions\": 1536,\n      \"score_threshold\": 0.75\n    },\n    \"unstructured\": {\n      \"partition_strategy\": \"auto\",\n      \"hi_res_model_name\": \"detectron2_onnx\",\n      \"process_tables\": false\n    },\n    \"splitter\": {\n      \"name\": \"semantic\",\n      \"min_tokens\": 30,\n      \"max_tokens\": 280,\n      \"rolling_window_size\": 1,\n      \"prefix_titles\": true,\n      \"prefix_summary\": true\n    },\n    \"parser_config\": {\n        \"structured_data_content_field\": \"page_content\"\n    }\n  },\n  \"webhook_url\": \"<string>\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/rag/ingest",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"rag",
+										"ingest"
+									]
+								},
+								"description": "Upload files for ingesting using the advanced RAG system."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"files\": [\n    \"<uuid>\",\n    \"<uuid>\"\n  ],\n  \"purpose\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"document_processor\": {\n    \"summarize\": false,\n    \"encoder\": {\n      \"provider\": \"openai\",\n      \"encoder_model\": \"text-embedding-3-small\",\n      \"dimensions\": 1536\n    },\n    \"unstructured\": {\n      \"partition_strategy\": \"auto\",\n      \"hi_res_model_name\": \"detectron2_onnx\",\n      \"process_tables\": false\n    },\n    \"splitter\": {\n      \"name\": \"semantic\",\n      \"min_tokens\": 30,\n      \"max_tokens\": 800,\n      \"rolling_window_size\": 1,\n      \"prefix_titles\": true,\n      \"prefix_summary\": true\n    }\n  },\n  \"webhook_url\": \"<string>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/rag/ingest",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"rag",
+												"ingest"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "\"<object>\""
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"files\": [\n    \"<uuid>\",\n    \"<uuid>\"\n  ],\n  \"purpose\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"document_processor\": {\n    \"summarize\": false,\n    \"encoder\": {\n      \"provider\": \"openai\",\n      \"encoder_model\": \"text-embedding-3-small\",\n      \"dimensions\": 1536\n    },\n    \"unstructured\": {\n      \"partition_strategy\": \"auto\",\n      \"hi_res_model_name\": \"detectron2_onnx\",\n      \"process_tables\": false\n    },\n    \"splitter\": {\n      \"name\": \"semantic\",\n      \"min_tokens\": 30,\n      \"max_tokens\": 800,\n      \"rolling_window_size\": 1,\n      \"prefix_titles\": true,\n      \"prefix_summary\": true\n    }\n  },\n  \"webhook_url\": \"<string>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/rag/ingest",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"rag",
+												"ingest"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Query documents",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/rag/query",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"rag",
+										"query"
+									]
+								},
+								"description": "Query ingested documents using advanced RAG system with unstructured library. <br>"
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/rag/query",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"rag",
+												"query"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"success\": \"<boolean>\",\n  \"data\": [\n    {\n      \"id\": \"<string>\",\n      \"document_id\": \"<string>\",\n      \"page_content\": \"<string>\",\n      \"file_id\": \"<string>\",\n      \"namespace\": \"<string>\",\n      \"source\": \"<string>\",\n      \"source_type\": \"<string>\",\n      \"chunk_index\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"purpose\": \"<string>\",\n      \"token_count\": \"<integer>\",\n      \"page_number\": \"<integer>\",\n      \"metadata\": \"<object>\",\n      \"dense_embedding\": [\n        \"<number>\",\n        \"<number>\"\n      ]\n    },\n    {\n      \"id\": \"<string>\",\n      \"document_id\": \"<string>\",\n      \"page_content\": \"<string>\",\n      \"file_id\": \"<string>\",\n      \"namespace\": \"<string>\",\n      \"source\": \"<string>\",\n      \"source_type\": \"<string>\",\n      \"chunk_index\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"purpose\": \"<string>\",\n      \"token_count\": \"<integer>\",\n      \"page_number\": \"<integer>\",\n      \"metadata\": \"<object>\",\n      \"dense_embedding\": [\n        \"<number>\",\n        \"<number>\"\n      ]\n    }\n  ]\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/rag/query",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"rag",
+												"query"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Query Lc Retriever",
+							"request": {
+								"auth": {
+									"type": "apikey",
+									"apikey": [
+										{
+											"key": "key",
+											"value": "X-API-KEY",
+											"type": "string"
+										},
+										{
+											"key": "value",
+											"value": "{{apiKey}}",
+											"type": "string"
+										},
+										{
+											"key": "in",
+											"value": "header",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/rag/query-lc-retriever",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"rag",
+										"query-lc-retriever"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/rag/query-lc-retriever",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"rag",
+												"query-lc-retriever"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"input\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"context\": \"<string>\",\n  \"index_name\": \"<string>\",\n  \"vector_database\": {\n    \"type\": \"qdrant\",\n    \"config\": \"<object>\"\n  },\n  \"encoder\": {\n    \"provider\": \"openai\",\n    \"encoder_model\": \"text-embedding-3-small\",\n    \"dimensions\": 1536\n  },\n  \"enable_rerank\": \"<boolean>\",\n  \"interpreter_mode\": \"<boolean>\",\n  \"exclude_fields\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/rag/query-lc-retriever",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"rag",
+												"query-lc-retriever"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "files",
+					"item": [
+						{
+							"name": "{file_id}",
+							"item": [
+								{
+									"name": "Retrieve file information",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"fileId\", \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\")"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response has valid JSON structure\", function () {",
+													"    pm.response.to.be.json;",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/files/{{fileId}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"files",
+												"{{fileId}}"
+											]
+										},
+										"description": "Retrieves information about a specific file by its ID."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/files/:file_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"files",
+														":file_id"
+													],
+													"variable": [
+														{
+															"key": "file_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"purpose\": \"<string>\",\n  \"filename\": \"<string>\",\n  \"bytes\": \"<integer>\",\n  \"mime_type\": \"<string>\",\n  \"source\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/files/:file_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"files",
+														":file_id"
+													],
+													"variable": [
+														{
+															"key": "file_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete a specific file",
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/files/:file_id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"files",
+												":file_id"
+											],
+											"variable": [
+												{
+													"key": "file_id",
+													"value": "<uuid>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "Deletes a specific file by its ID from the database and file system. When a file is deleted, it is also removed from any assistants that may be using it and all associated embeddings are deleted from the vector store."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/files/:file_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"files",
+														":file_id"
+													],
+													"variable": [
+														{
+															"key": "file_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"file_id\": \"<uuid>\",\n  \"num_of_assistants\": \"<integer>\",\n  \"assistants\": [\n    \"<object>\",\n    \"<object>\"\n  ],\n  \"num_of_deleted_chunks\": \"<integer>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/files/:file_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"files",
+														":file_id"
+													],
+													"variable": [
+														{
+															"key": "file_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Retrieve the content of a specific file",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"fileId\", \"1e538b9d-ef2d-47d4-ad16-5d76080f3e7c\")"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/files/{{fileId}}/content",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"files",
+												"{{fileId}}",
+												"content"
+											]
+										},
+										"description": "Retrieves the content of a specific file by its ID. Returns a downloadable file."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/files/:file_id/content",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"files",
+														":file_id",
+														"content"
+													],
+													"variable": [
+														{
+															"key": "file_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-API-KEY",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/files/:file_id/content",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"files",
+														":file_id",
+														"content"
+													],
+													"variable": [
+														{
+															"key": "file_id",
+															"value": "<uuid>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								}
+							]
+						},
+						{
+							"name": "Upload a file",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const uuid = require('uuid');",
+											"",
+											"pm.variables.set('file_name', uuid.v4());"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"Response has valid JSON structure\", function () {",
+											"    pm.response.to.be.json;",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "multipart/form-data"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"description": "(Required) The file to upload.",
+											"type": "file",
+											"src": "postman-cloud:///1ef379dd-c051-4b10-98ce-f78ec7887dbe"
+										},
+										{
+											"key": "purpose",
+											"value": "assistants",
+											"description": "(Required) The purpose of the file: 'assistants', 'threads', or 'personas'.",
+											"type": "text"
+										},
+										{
+											"key": "kwargs",
+											"value": "{}",
+											"description": "Any additonal metadata to include for this file. This should be a JSON string.",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/files",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"files"
+									]
+								},
+								"description": "Uploads a file that can be used across various endpoints. <br> NOTE: MUST INCLUDE `user_id`"
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "file",
+													"value": "<binary>",
+													"description": "(Required) The file to upload.",
+													"type": "text"
+												},
+												{
+													"key": "purpose",
+													"value": "<string>",
+													"description": "(Required) The purpose of the file: 'assistants', 'threads', or 'personas'.",
+													"type": "text"
+												},
+												{
+													"key": "user_id",
+													"value": "<string>",
+													"description": "(Required) The user id of the file owner.",
+													"type": "text"
+												},
+												{
+													"key": "filename",
+													"value": "<string>",
+													"description": "The preferred name for the file.",
+													"type": "text"
+												},
+												{
+													"key": "kwargs",
+													"value": "<string>",
+													"description": "Any additonal metadata to include for this file. This should be a JSON string.",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/files",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"files"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"<uuid>\",\n  \"user_id\": \"<string>\",\n  \"purpose\": \"<string>\",\n  \"filename\": \"<string>\",\n  \"bytes\": \"<integer>\",\n  \"mime_type\": \"<string>\",\n  \"source\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "file",
+													"value": "<binary>",
+													"description": "(Required) The file to upload.",
+													"type": "text"
+												},
+												{
+													"key": "purpose",
+													"value": "<string>",
+													"description": "(Required) The purpose of the file: 'assistants', 'threads', or 'personas'.",
+													"type": "text"
+												},
+												{
+													"key": "user_id",
+													"value": "<string>",
+													"description": "(Required) The user id of the file owner.",
+													"type": "text"
+												},
+												{
+													"key": "filename",
+													"value": "<string>",
+													"description": "The preferred name for the file.",
+													"type": "text"
+												},
+												{
+													"key": "kwargs",
+													"value": "<string>",
+													"description": "Any additonal metadata to include for this file. This should be a JSON string.",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/files",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"files"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Retrieve files",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Response has valid JSON structure\", function () {",
+											"    pm.response.to.be.json;",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/files?user_id={{userId}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"files"
+									],
+									"query": [
+										{
+											"key": "user_id",
+											"value": "{{userId}}"
+										}
+									]
+								},
+								"description": "Retrieves a list of files."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/files?user_id=<string>&purpose=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"files"
+											],
+											"query": [
+												{
+													"key": "user_id",
+													"value": "<string>"
+												},
+												{
+													"key": "purpose",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"purpose\": \"<string>\",\n    \"filename\": \"<string>\",\n    \"bytes\": \"<integer>\",\n    \"mime_type\": \"<string>\",\n    \"source\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\"\n  }\n]"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-API-KEY",
+												"value": "<API Key>",
+												"description": "Added as a part of security scheme: apikey"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/files?user_id=<string>&purpose=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"files"
+											],
+											"query": [
+												{
+													"key": "user_id",
+													"value": "<string>"
+												},
+												{
+													"key": "purpose",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "auth",
+					"item": [
+						{
+							"name": "Get enabled authentication strategies",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/auth/auth_strategies",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"auth",
+										"auth_strategies"
+									]
+								},
+								"description": "Returns a list of enabled authentication strategies."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/auth/auth_strategies",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"auth",
+												"auth_strategies"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  {\n    \"strategy\": \"<string>\",\n    \"client_id\": \"<string>\",\n    \"authorization_endpoint\": \"<string>\",\n    \"pkce_enabled\": \"<boolean>\"\n  },\n  {\n    \"strategy\": \"<string>\",\n    \"client_id\": \"<string>\",\n    \"authorization_endpoint\": \"<string>\",\n    \"pkce_enabled\": \"<boolean>\"\n  }\n]"
+								}
+							]
+						},
+						{
+							"name": "Login",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"strategy\": \"<string>\",\n  \"payload\": {\n    \"qui_d7e\": \"<string>\",\n    \"mollit4a1\": \"<string>\",\n    \"reprehenderit9_2\": \"<string>\",\n    \"est_8c\": \"<string>\"\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/auth/login",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"auth",
+										"login"
+									]
+								},
+								"description": "Logs user in, performing auth according to auth strategy."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"strategy\": \"<string>\",\n  \"payload\": {\n    \"qui_d7e\": \"<string>\",\n    \"mollit4a1\": \"<string>\",\n    \"reprehenderit9_2\": \"<string>\",\n    \"est_8c\": \"<string>\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/auth/login",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"auth",
+												"login"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"token\": \"<string>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"strategy\": \"<string>\",\n  \"payload\": {\n    \"qui_d7e\": \"<string>\",\n    \"mollit4a1\": \"<string>\",\n    \"reprehenderit9_2\": \"<string>\",\n    \"est_8c\": \"<string>\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/auth/login",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"auth",
+												"login"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Authorize",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/auth/:strategy/auth?code=<string>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"auth",
+										":strategy",
+										"auth"
+									],
+									"query": [
+										{
+											"key": "code",
+											"value": "<string>",
+											"description": "Code returned from OAuth provider for OIDC token exchange"
+										}
+									],
+									"variable": [
+										{
+											"key": "strategy",
+											"value": "<string>",
+											"description": "(Required) "
+										}
+									]
+								},
+								"description": "Callback authorization endpoint used for OAuth providers after authenticating on the provider's login screen."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/auth/:strategy/auth",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"auth",
+												":strategy",
+												"auth"
+											],
+											"variable": [
+												{
+													"key": "strategy",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"token\": \"<string>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/auth/:strategy/auth",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"auth",
+												":strategy",
+												"auth"
+											],
+											"variable": [
+												{
+													"key": "strategy",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Logout",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/auth/logout",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"auth",
+										"logout"
+									]
+								},
+								"description": "Logs user out, adding the given JWT token to the blacklist."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/auth/logout",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"auth",
+												"logout"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "admin/users",
+					"item": [
+						{
+							"name": "{user_id}",
+							"item": [
+								{
+									"name": "Retrieve a specific user",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response has valid JSON structure\", function () {",
+													"    pm.response.to.be.json;",
+													"    const responseJson = pm.response.json();",
+													"    pm.expect(responseJson).to.have.property('user_id');",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users",
+												":user_id"
+											],
+											"variable": [
+												{
+													"key": "user_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "GET endpoint at `/users/{user_id}` for fetching details of a specific user using its user_id.\n        USAGE: Admins can use this endpoint to retrieve details of a specific user.\n        TODO: Add access control for this endpoint."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id"
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id"
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Update a specific user ",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response has valid JSON structure\", function () {",
+													"    pm.response.to.be.json;",
+													"    const responseJson = pm.response.json();",
+													"    pm.expect(responseJson).to.have.property('user_id');",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users",
+												":user_id"
+											],
+											"variable": [
+												{
+													"key": "user_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "PATCH endpoint at `/{user_id}` for updating the details of a specific user.\n        USAGE: Admins can use this endpoint to update the details of a specific user.\n        TODO: Add access control for this endpoint."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id"
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id"
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Retrieve user assistants",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users/:user_id/assistants",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users",
+												":user_id",
+												"assistants"
+											],
+											"variable": [
+												{
+													"key": "user_id",
+													"value": "<string>",
+													"description": "Required"
+												}
+											]
+										},
+										"description": "Retrieves a list of the user's assistants."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/assistants",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														"assistants"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 3.5 Turbo\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"config\": {\n      \"configurable\": {\n        \"type\": \"agent\",\n        \"agent_type\": \"GPT 3.5 Turbo\",\n        \"interrupt_before_action\": \"<boolean>\",\n        \"retrieval_description\": \"<string>\",\n        \"system_message\": \"<string>\",\n        \"tools\": [\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          },\n          {\n            \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n          }\n        ],\n        \"llm_type\": {\n          \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n        }\n      }\n    },\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"user_id\": \"<string>\",\n    \"kwargs\": \"<object>\",\n    \"file_ids\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"public\": \"<boolean>\"\n  }\n]"
+										}
+									]
+								},
+								{
+									"name": "Delete a specific user ",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users",
+												":user_id"
+											],
+											"variable": [
+												{
+													"key": "user_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "DELETE endpoint at `/users/{user_id}` for removing a specific user using its `user_id`.\n                USAGE: Admins can use this endpoint to delete a specific user.\n                TODO: Add access control for this endpoint."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id"
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "text/plain"
+												}
+											],
+											"cookie": [],
+											"body": ""
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id"
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Retrieve threads by user ",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response has valid JSON structure\", function () {",
+													"    pm.response.to.be.json;",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users/:user_id/threads?grouped=<boolean>&timezoneOffset=<integer>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users",
+												":user_id",
+												"threads"
+											],
+											"query": [
+												{
+													"key": "grouped",
+													"value": "<boolean>"
+												},
+												{
+													"key": "timezoneOffset",
+													"value": "<integer>"
+												}
+											],
+											"variable": [
+												{
+													"key": "user_id",
+													"value": "<string>",
+													"description": "(Required) "
+												}
+											]
+										},
+										"description": "GET endpoint at `/users/{user_id}/threads` for fetching all threads associated with a specific user using its id. <br>\n                USAGE: Admins can use this endpoint to retrieve all threads associated with a specific user.\n                TODO: Add access control for this endpoint."
+									},
+									"response": [
+										{
+											"name": "Successful Response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id/threads?grouped=<boolean>&timezoneOffset=<integer>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id",
+														"threads"
+													],
+													"query": [
+														{
+															"key": "grouped",
+															"value": "<boolean>"
+														},
+														{
+															"key": "timezoneOffset",
+															"value": "<integer>"
+														}
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
+										},
+										{
+											"name": "Validation Error",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer <token>",
+														"description": "Added as a part of security scheme: bearer"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/api/v1/admin/users/:user_id/threads?grouped=<boolean>&timezoneOffset=<integer>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"api",
+														"v1",
+														"admin",
+														"users",
+														":user_id",
+														"threads"
+													],
+													"query": [
+														{
+															"key": "grouped",
+															"value": "<boolean>"
+														},
+														{
+															"key": "timezoneOffset",
+															"value": "<integer>"
+														}
+													],
+													"variable": [
+														{
+															"key": "user_id",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+											"code": 422,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+										}
+									]
+								}
+							]
+						},
+						{
+							"name": "List all users ",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Response has valid JSON structure\", function () {",
+											"    pm.response.to.be.json;",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{bearerToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/admin/users",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"admin",
+										"users"
+									]
+								},
+								"description": "GET endpoint at `/users` for listing all users.\n                TODO: Add access control for this endpoint."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  {\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"email\": \"<string>\",\n    \"first_name\": \"<string>\",\n    \"last_name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"username\": \"<string>\",\n    \"email\": \"<string>\",\n    \"first_name\": \"<string>\",\n    \"last_name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
+								}
+							]
+						},
+						{
+							"name": "Create a new user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Response has valid JSON structure\", function () {",
+											"    pm.response.to.be.json;",
+											"    const responseJson = pm.response.json();",
+											"    pm.expect(responseJson).to.have.property('user_id');",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"user_id\": \"<string>\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/admin/users",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"admin",
+										"users"
+									]
+								},
+								"description": "POST endpoint at `/users` for creating a new user.\n                If `user_id` is not present, the database will auto-generate a new UUID for the field.\n                This is intended to allow for internal users to be correlated with external systems while not exposing the internal database record id for the user.\n                TODO: Add access control for this endpoint."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\",\n  \"user_id\": \"<string>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\",\n  \"user_id\": \"<string>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Retrieve all threads",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/admin/users/threads",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"admin",
+										"users",
+										"threads"
+									]
+								},
+								"description": "Retrieves a list of all threads in the database.\n                Should be used as an admin operation. <br>\n                TODO: Add access control for this endpoint."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/admin/users/threads",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"admin",
+												"users",
+												"threads"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "users/me",
+					"item": [
+						{
+							"name": "Retrieve a specific user ",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/users/me",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"users",
+										"me"
+									]
+								},
+								"description": "GET endpoint to fetch details of the logged-in user.\n        USAGE: Admins can use this endpoint to retrieve details of a specific user.\n        TODO: Add RBAC for this endpoint."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/users/me",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"users",
+												"me"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Delete a specific user ",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/users/me",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"users",
+										"me"
+									]
+								},
+								"description": "DELETE endpoint for removing the logged-in user from the system.\n                This will do a cascade delete on all threads and messages, but will not\n                effect assistants created by the user."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/users/me",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"users",
+												"me"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Update a specific user ",
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/users/me",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"users",
+										"me"
+									]
+								},
+								"description": "PATCH endpoint for updating the details of the logged-in user."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/users/me",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"users",
+												"me"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"user_id\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"updated_at\": \"<dateTime>\",\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\"\n}"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"username\": \"<string>\",\n  \"email\": \"<string>\",\n  \"first_name\": \"<string>\",\n  \"last_name\": \"<string>\",\n  \"kwargs\": \"<object>\",\n  \"password\": \"<string>\",\n  \"hashed_password\": \"<binary>\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/users/me",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"users",
+												"me"
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Retrieve threads by user ",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/users/me/threads?grouped=<boolean>&timezoneOffset=<integer>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"users",
+										"me",
+										"threads"
+									],
+									"query": [
+										{
+											"key": "grouped",
+											"value": "<boolean>",
+											"description": "Group threads into date categories (eg. Today, Yesterday, etc.)"
+										},
+										{
+											"key": "timezoneOffset",
+											"value": "<integer>",
+											"description": "Timezone offset in minutes from UTC"
+										}
+									]
+								},
+								"description": "GET endpoint for fetching all threads associated with the logged-in user."
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/users/me/threads?grouped=<boolean>&timezoneOffset=<integer>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"users",
+												"me",
+												"threads"
+											],
+											"query": [
+												{
+													"key": "grouped",
+													"value": "<boolean>"
+												},
+												{
+													"key": "timezoneOffset",
+													"value": "<integer>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  },\n  {\n    \"id\": \"<uuid>\",\n    \"user_id\": \"<string>\",\n    \"created_at\": \"<dateTime>\",\n    \"updated_at\": \"<dateTime>\",\n    \"assistant_id\": \"<uuid>\",\n    \"name\": \"<string>\",\n    \"kwargs\": \"<object>\"\n  }\n]"
+								},
+								{
+									"name": "Validation Error",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <token>",
+												"description": "Added as a part of security scheme: bearer"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/api/v1/users/me/threads?grouped=<boolean>&timezoneOffset=<integer>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"users",
+												"me",
+												"threads"
+											],
+											"query": [
+												{
+													"key": "grouped",
+													"value": "<boolean>"
+												},
+												{
+													"key": "timezoneOffset",
+													"value": "<integer>"
+												}
+											]
+										}
+									},
+									"status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+									"code": 422,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    },\n    {\n      \"loc\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"msg\": \"<string>\",\n      \"type\": \"<string>\"\n    }\n  ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Health Check",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v1/health_check",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"health_check"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Successful Response",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/health_check",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"health_check"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{}"
+						}
+					]
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:9000",
+			"type": "string"
+		}
+	]
 }

--- a/stack/tests/integration/openapi.json
+++ b/stack/tests/integration/openapi.json
@@ -11,7 +11,9 @@
   "paths": {
     "/api/v1/runs/stream": {
       "post": {
-        "tags": ["Runs"],
+        "tags": [
+          "Runs"
+        ],
         "summary": "Stream an LLM run.",
         "description": "Endpoint to stream an LLM response. If the thread_id is not provided, a new thread will be created as long as the assistant_id is included. \u003Cbr\u003E\n                Note that the input should be a list of messages in the format: \u003Cbr\u003E\n                content: string \u003Cbr\u003E\n                role: string \u003Cbr\u003E\n                additional_kwargs: dict \u003Cbr\u003E\n                example: bool \u003Cbr\u003E",
         "operationId": "stream_run",
@@ -49,7 +51,9 @@
     },
     "/api/v1/runs": {
       "post": {
-        "tags": ["Runs"],
+        "tags": [
+          "Runs"
+        ],
         "summary": "Create a run",
         "description": "Create a run to be processed by the LLM.",
         "operationId": "create_run",
@@ -95,7 +99,9 @@
     },
     "/api/v1/runs/input_schema": {
       "get": {
-        "tags": ["Runs"],
+        "tags": [
+          "Runs"
+        ],
         "summary": "Return the input schema of the runnable.",
         "description": "Return the input schema of the runnable.",
         "operationId": "get_input_schema",
@@ -121,7 +127,9 @@
     },
     "/api/v1/runs/output_schema": {
       "get": {
-        "tags": ["Runs"],
+        "tags": [
+          "Runs"
+        ],
         "summary": "Return the output schema of the runnable.",
         "description": "Return the output schema of the runnable.",
         "operationId": "get_output_schema",
@@ -147,7 +155,9 @@
     },
     "/api/v1/runs/config_schema": {
       "get": {
-        "tags": ["Runs"],
+        "tags": [
+          "Runs"
+        ],
         "summary": "Return the config schema of the runnable.",
         "description": "Return the config schema of the runnable.",
         "operationId": "get_config_schema",
@@ -173,7 +183,9 @@
     },
     "/api/v1/runs/title": {
       "post": {
-        "tags": ["Runs"],
+        "tags": [
+          "Runs"
+        ],
         "summary": "Generate a title to name the thread.",
         "description": "Generates a title for the conversation by sending a list of interactions to the model.",
         "operationId": "generate_title",
@@ -216,11 +228,61 @@
         ]
       }
     },
+    "/api/v1/runs/feedback": {
+      "post": {
+        "tags": [
+          "Feedback"
+        ],
+        "summary": "Send feedback on an individual run to langsmith",
+        "description": "Send feedback on an individual run to langsmith. **Disabled if ENABLE_LANGSMITH_TRACING is not explicitly set to `true`**.",
+        "operationId": "create_run_feedback_api_v1_runs_feedback_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Create Run Feedback Api V1 Runs Feedback Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer Auth": []
+          }
+        ]
+      }
+    },
     "/api/v1/users/me": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Retrieve a specific user ",
-        "description": "GET endpoint to fetch details of the logged-in user.\n        USAGE: Admins can use this endpoint to retrieve details of a specific user.\n        TODO: Add RBAC for this endpoint.",
+        "description": "GET endpoint to fetch details of the logged-in user.",
         "operationId": "retrieve_me",
         "responses": {
           "200": {
@@ -241,7 +303,9 @@
         ]
       },
       "delete": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete a specific user ",
         "description": "DELETE endpoint for removing the logged-in user from the system.\n                This will do a cascade delete on all threads and messages, but will not\n                effect assistants created by the user.",
         "operationId": "delete_me",
@@ -257,7 +321,9 @@
         ]
       },
       "patch": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update a specific user ",
         "description": "PATCH endpoint for updating the details of the logged-in user.",
         "operationId": "update_me",
@@ -302,7 +368,9 @@
     },
     "/api/v1/users/me/threads": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Retrieve threads by user ",
         "description": "GET endpoint for fetching all threads associated with the logged-in user.",
         "operationId": "retrieve_threads",
@@ -386,7 +454,9 @@
     },
     "/api/v1/threads": {
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Create a new thread",
         "description": "Creates a new thread with the provided information. This can optionally be obtained from the api_key. If it is not set in the request, it will attempt to get it from the api_key.",
         "operationId": "create_thread",
@@ -431,7 +501,9 @@
     },
     "/api/v1/threads/{thread_id}": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Retrieve a specific thread",
         "description": "Retrieves detailed information about a thread identified by its ID.",
         "operationId": "retrieve_thread",
@@ -475,7 +547,9 @@
         ]
       },
       "patch": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Update a specific thread",
         "description": "Updates the information of a thread identified by its ID.",
         "operationId": "update_thread",
@@ -529,7 +603,9 @@
         ]
       },
       "delete": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Delete a specific thread",
         "description": "Deletes a thread identified by its ID from the database.",
         "operationId": "delete_thread",
@@ -568,7 +644,9 @@
     },
     "/api/v1/threads/{thread_id}/state": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Retrieve thread state",
         "description": "Retrieves the state of a thread identified by its ID.",
         "operationId": "retrieve_thread_state",
@@ -588,7 +666,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+
+                }
               }
             }
           },
@@ -610,7 +690,9 @@
         ]
       },
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Add thread state",
         "description": "Adds the state of a thread identified by its ID.",
         "operationId": "add_thread_state",
@@ -640,7 +722,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+
+                }
               }
             }
           },
@@ -664,7 +748,9 @@
     },
     "/api/v1/threads/{thread_id}/history": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Get thread history",
         "description": "Gets the history of the thread identified by its ID.",
         "operationId": "get_thread_history",
@@ -684,7 +770,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+
+                }
               }
             }
           },
@@ -708,7 +796,9 @@
     },
     "/api/v1/assistants": {
       "get": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Retrieve user assistants",
         "description": "Retrieves a list of the user's assistants.",
         "operationId": "retrieve_user_assistants",
@@ -735,7 +825,9 @@
         ]
       },
       "post": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Create a new assistant",
         "description": "Creates a new assistant with the specified details.",
         "operationId": "create_assistant",
@@ -780,7 +872,9 @@
     },
     "/api/v1/assistants/{assistant_id}": {
       "get": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Retrieve a specific assistant",
         "description": "Retrieves detailed information about a specific assistant by its ID.",
         "operationId": "retrieve_assistant",
@@ -825,7 +919,9 @@
         ]
       },
       "patch": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Update a specific assistant",
         "description": "Updates the details of a specific assistant by its ID.",
         "operationId": "update_assistant",
@@ -880,7 +976,9 @@
         ]
       },
       "delete": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Delete a specific assistant",
         "description": "Deletes a specific assistant by its ID from the database.",
         "operationId": "delete_assistant",
@@ -920,7 +1018,9 @@
     },
     "/api/v1/assistants/{assistant_id}/files": {
       "post": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Add an uploaded file to an assistant for RAG.",
         "description": "Convenience method to add an uploaded file to an assistant for RAG ingestion and retrieval",
         "operationId": "create_assistant_file",
@@ -975,7 +1075,9 @@
         ]
       },
       "get": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Retrieve file information for all files associated with an assistant",
         "description": "Returns a list of file objects for all files associated with an assistant.",
         "operationId": "retrieve_assistant_files",
@@ -1080,7 +1182,9 @@
     },
     "/api/v1/assistants/{assistant_id}/files/{file_id}": {
       "delete": {
-        "tags": ["Assistants"],
+        "tags": [
+          "Assistants"
+        ],
         "summary": "Remove a file from an assistant",
         "description": "Removes a file from an assistant by its ID. This also deletes the corresponding documents from the vector store.",
         "operationId": "delete_assistant_file",
@@ -1137,7 +1241,9 @@
     },
     "/api/v1/rag/ingest": {
       "post": {
-        "tags": ["RAG"],
+        "tags": [
+          "RAG"
+        ],
         "summary": "Ingest files to be indexed and queried.",
         "description": "Upload files for ingesting using the advanced RAG system.",
         "operationId": "ingest_data_from_files",
@@ -1183,7 +1289,9 @@
     },
     "/api/v1/rag/query": {
       "post": {
-        "tags": ["RAG"],
+        "tags": [
+          "RAG"
+        ],
         "summary": "Query documents",
         "description": "Query ingested documents using advanced RAG system with unstructured library. \u003Cbr\u003E",
         "operationId": "query_documents",
@@ -1228,7 +1336,9 @@
     },
     "/api/v1/rag/query-lc-retriever": {
       "post": {
-        "tags": ["RAG"],
+        "tags": [
+          "RAG"
+        ],
         "summary": "Query Lc Retriever",
         "operationId": "query_lc_retriever_api_v1_rag_query_lc_retriever_post",
         "requestBody": {
@@ -1246,7 +1356,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+
+                }
               }
             }
           },
@@ -1270,7 +1382,9 @@
     },
     "/api/v1/files": {
       "post": {
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "summary": "Upload a file",
         "description": "Uploads a file that can be used across various endpoints. \u003Cbr\u003E NOTE: MUST INCLUDE `user_id`",
         "operationId": "upload_file",
@@ -1313,7 +1427,9 @@
         ]
       },
       "get": {
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "summary": "Retrieve files",
         "description": "Retrieves a list of files.",
         "operationId": "retrieve_files_for_user",
@@ -1370,7 +1486,9 @@
     },
     "/api/v1/files/{file_id}": {
       "get": {
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "summary": "Retrieve file information",
         "description": "Retrieves information about a specific file by its ID.",
         "operationId": "retrieve_file",
@@ -1415,7 +1533,9 @@
         ]
       },
       "delete": {
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "summary": "Delete a specific file",
         "description": "Deletes a specific file by its ID from the database and file system. When a file is deleted, it is also removed from any assistants that may be using it and all associated embeddings are deleted from the vector store.",
         "operationId": "delete_file",
@@ -1462,7 +1582,9 @@
     },
     "/api/v1/files/{file_id}/content": {
       "get": {
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "summary": "Retrieve the content of a specific file",
         "description": "Retrieves the content of a specific file by its ID. Returns a downloadable file.",
         "operationId": "retrieve_file_content",
@@ -1483,7 +1605,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+
+                }
               }
             }
           },
@@ -1507,7 +1631,9 @@
     },
     "/api/v1/auth/auth_strategies": {
       "get": {
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "summary": "Get enabled authentication strategies",
         "description": "Returns a list of enabled authentication strategies.",
         "operationId": "get_auth_strategies",
@@ -1536,7 +1662,9 @@
     },
     "/api/v1/auth/login": {
       "post": {
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "summary": "Login",
         "description": "Logs user in, performing auth according to auth strategy.",
         "operationId": "login",
@@ -1589,7 +1717,9 @@
     },
     "/api/v1/auth/{strategy}/auth": {
       "post": {
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "summary": "Authorize",
         "description": "Callback authorization endpoint used for OAuth providers after authenticating on the provider's login screen.",
         "operationId": "authorize",
@@ -1646,7 +1776,9 @@
     },
     "/api/v1/auth/logout": {
       "get": {
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "summary": "Logout",
         "description": "Logs user out, adding the given JWT token to the blacklist.",
         "operationId": "logout",
@@ -1671,7 +1803,9 @@
     },
     "/api/v1/admin/users": {
       "get": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "List all users ",
         "description": "GET endpoint at `/users` for listing all users.\n                TODO: Add access control for this endpoint.",
         "operationId": "retrieve_all_users",
@@ -1698,7 +1832,9 @@
         ]
       },
       "post": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "Create a new user",
         "description": "POST endpoint at `/users` for creating a new user.\n                If `user_id` is not present, the database will auto-generate a new UUID for the field.\n                This is intended to allow for internal users to be correlated with external systems while not exposing the internal database record id for the user.\n                TODO: Add access control for this endpoint.",
         "operationId": "create_user",
@@ -1743,7 +1879,9 @@
     },
     "/api/v1/admin/users/{user_id}": {
       "get": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "Retrieve a specific user",
         "description": "GET endpoint at `/users/{user_id}` for fetching details of a specific user using its user_id.\n        USAGE: Admins can use this endpoint to retrieve details of a specific user.\n        TODO: Add access control for this endpoint.",
         "operationId": "retrieve_user",
@@ -1794,7 +1932,9 @@
         ]
       },
       "patch": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "Update a specific user ",
         "description": "PATCH endpoint at `/{user_id}` for updating the details of a specific user.\n        USAGE: Admins can use this endpoint to update the details of a specific user.\n        TODO: Add access control for this endpoint.",
         "operationId": "update_user",
@@ -1848,7 +1988,9 @@
         ]
       },
       "delete": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "Delete a specific user ",
         "description": "DELETE endpoint at `/users/{user_id}` for removing a specific user using its `user_id`.\n                USAGE: Admins can use this endpoint to delete a specific user.\n                TODO: Add access control for this endpoint.",
         "operationId": "delete_user",
@@ -1887,7 +2029,9 @@
     },
     "/api/v1/admin/users/{user_id}/threads": {
       "get": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "Retrieve threads by user ",
         "description": "GET endpoint at `/users/{user_id}/threads` for fetching all threads associated with a specific user using its id. \u003Cbr\u003E\n                USAGE: Admins can use this endpoint to retrieve all threads associated with a specific user.\n                TODO: Add access control for this endpoint.",
         "operationId": "retrieve_user_threads",
@@ -1976,7 +2120,9 @@
     },
     "/api/v1/admin/users/threads": {
       "get": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "Retrieve all threads",
         "description": "Retrieves a list of all threads in the database.\n                Should be used as an admin operation. \u003Cbr\u003E\n                TODO: Add access control for this endpoint.",
         "operationId": "retrieve_all_threads",
@@ -2005,7 +2151,9 @@
     },
     "/api/v1/admin/users/{user_id}/assistants": {
       "get": {
-        "tags": ["Users (Admin)"],
+        "tags": [
+          "Users (Admin)"
+        ],
         "summary": "Retrieve user assistants",
         "description": "Retrieves a list of the user's assistants.",
         "operationId": "retrieve_user_assistants",
@@ -2055,7 +2203,9 @@
     },
     "/api/v1/health_check": {
       "get": {
-        "tags": ["Health Check"],
+        "tags": [
+          "Health Check"
+        ],
         "summary": "Health Check",
         "operationId": "health_check_api_v1_health_check_get",
         "responses": {
@@ -2063,7 +2213,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+
+                }
               }
             }
           }
@@ -2180,8 +2332,33 @@
           }
         },
         "type": "object",
-        "required": ["id", "name", "config", "created_at", "updated_at"],
+        "required": [
+          "id",
+          "name",
+          "config",
+          "created_at",
+          "updated_at"
+        ],
         "title": "Assistant"
+      },
+      "AvailableTools": {
+        "type": "string",
+        "enum": [
+          "action_server_by_robocorp",
+          "ai_action_runner_by_connery",
+          "ddg_search",
+          "search_tavily",
+          "search_tavily_answer",
+          "retrieval",
+          "arxiv",
+          "you_search",
+          "sec_filings_kai_ai",
+          "press_releases_kai_ai",
+          "pubmed",
+          "wikipedia",
+          "dall_e"
+        ],
+        "title": "AvailableTools"
       },
       "BaseDocumentChunk": {
         "properties": {
@@ -2189,24 +2366,9 @@
             "type": "string",
             "title": "Id"
           },
-          "document_id": {
-            "type": "string",
-            "title": "Document Id"
-          },
           "page_content": {
             "type": "string",
             "title": "Page Content"
-          },
-          "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "File Id"
           },
           "namespace": {
             "anyOf": [
@@ -2219,91 +2381,8 @@
             ],
             "title": "Namespace"
           },
-          "source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source"
-          },
-          "source_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Type"
-          },
-          "chunk_index": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Chunk Index"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "purpose": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ContextType"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "token_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Token Count"
-          },
-          "page_number": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Page Number"
-          },
           "metadata": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "object",
             "title": "Metadata"
           },
           "dense_embedding": {
@@ -2322,7 +2401,10 @@
           }
         },
         "type": "object",
-        "required": ["id", "document_id", "page_content"],
+        "required": [
+          "id",
+          "page_content"
+        ],
         "title": "BaseDocumentChunk"
       },
       "Body_upload_file": {
@@ -2334,11 +2416,6 @@
             "description": "The file to upload."
           },
           "purpose": {
-            "type": "string",
-            "title": "Purpose",
-            "description": "The purpose of the file: 'assistants', 'threads', or 'personas'."
-          },
-          "filename": {
             "anyOf": [
               {
                 "type": "string"
@@ -2347,8 +2424,8 @@
                 "type": "null"
               }
             ],
-            "title": "Filename",
-            "description": "The preferred name for the file."
+            "title": "Purpose",
+            "description": "The purpose of the file: 'assistants', 'threads', or 'personas'."
           },
           "kwargs": {
             "anyOf": [
@@ -2360,16 +2437,22 @@
               }
             ],
             "title": "Kwargs",
-            "description": "Any additonal metadata to include for this file. This should be a JSON string."
+            "description": "Any additional metadata to include for this file. This should be a JSON string."
           }
         },
         "type": "object",
-        "required": ["file", "purpose"],
+        "required": [
+          "file"
+        ],
         "title": "Body_upload_file"
       },
       "BotType": {
         "type": "string",
-        "enum": ["chatbot", "chat_retrieval", "agent"],
+        "enum": [
+          "chatbot",
+          "chat_retrieval",
+          "agent"
+        ],
         "title": "BotType"
       },
       "ChatMessage": {
@@ -2384,7 +2467,10 @@
           }
         },
         "type": "object",
-        "required": ["content", "type"],
+        "required": [
+          "content",
+          "type"
+        ],
         "title": "ChatMessage"
       },
       "Configurable": {
@@ -2452,7 +2538,7 @@
             "anyOf": [
               {
                 "items": {
-                  "$ref": "#/components/schemas/Tools"
+                  "$ref": "#/components/schemas/Tool"
                 },
                 "type": "array"
               },
@@ -2483,7 +2569,12 @@
       },
       "ContextType": {
         "type": "string",
-        "enum": ["assistants", "threads", "rag", "personas"],
+        "enum": [
+          "assistants",
+          "threads",
+          "rag",
+          "personas"
+        ],
         "title": "ContextType",
         "description": "Context where files or generated embeddings are used."
       },
@@ -2496,7 +2587,9 @@
           }
         },
         "type": "object",
-        "required": ["file_id"],
+        "required": [
+          "file_id"
+        ],
         "title": "CreateAssistantFileSchema"
       },
       "CreateAssistantFileSchemaResponse": {
@@ -2513,7 +2606,10 @@
           }
         },
         "type": "object",
-        "required": ["file_id", "assistant_id"],
+        "required": [
+          "file_id",
+          "assistant_id"
+        ],
         "title": "CreateAssistantFileSchemaResponse"
       },
       "CreateAssistantSchema": {
@@ -2571,7 +2667,10 @@
           }
         },
         "type": "object",
-        "required": ["name", "config"],
+        "required": [
+          "name",
+          "config"
+        ],
         "title": "CreateAssistantSchema"
       },
       "CreateRunPayload": {
@@ -2617,7 +2716,9 @@
           }
         },
         "type": "object",
-        "required": ["input"],
+        "required": [
+          "input"
+        ],
         "title": "CreateRunPayload",
         "description": "Payload for creating a run."
       },
@@ -2655,7 +2756,9 @@
           }
         },
         "type": "object",
-        "required": ["assistant_id"],
+        "required": [
+          "assistant_id"
+        ],
         "title": "CreateThreadSchema"
       },
       "CreateUpdateUserSchema": {
@@ -2783,7 +2886,11 @@
           }
         },
         "type": "object",
-        "required": ["file_id", "num_of_assistants", "assistants"],
+        "required": [
+          "file_id",
+          "num_of_assistants",
+          "assistants"
+        ],
         "title": "DeleteFileResponse"
       },
       "DocumentProcessorConfig": {
@@ -2804,7 +2911,8 @@
             "default": {
               "provider": "openai",
               "encoder_model": "text-embedding-3-small",
-              "dimensions": 1536
+              "dimensions": "1536",
+              "score_threshold": 0.5
             }
           },
           "unstructured": {
@@ -2835,6 +2943,20 @@
               "prefix_titles": true,
               "prefix_summary": true
             }
+          },
+          "parser_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ParserConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Content-specific keyword arguments for processing",
+            "default": {
+              "structured_data_content_field": "page_content"
+            }
           }
         },
         "type": "object",
@@ -2861,7 +2983,13 @@
             "type": "integer",
             "title": "Dimensions",
             "description": "Dimension of the encoder output",
-            "default": 1536
+            "default": "1536"
+          },
+          "score_threshold": {
+            "type": "number",
+            "title": "Score Threshold",
+            "description": "Score threshold for the encoder",
+            "default": 0.5
           }
         },
         "type": "object",
@@ -2878,6 +3006,77 @@
           "ollama"
         ],
         "title": "EncoderProvider"
+      },
+      "FeedbackCreateRequest": {
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Run Id"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          },
+          "comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comment"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run_id",
+          "key"
+        ],
+        "title": "FeedbackCreateRequest",
+        "description": "Represents a request that creates feedback for an individual run."
       },
       "FileSchema": {
         "properties": {
@@ -3091,7 +3290,7 @@
             ],
             "title": "Index Name",
             "description": "Name of the vector database follection to ingest the files into. If not provided, the `VECTOR_DB_COLLECTION_NAME` env var is used.",
-            "default": "documents"
+            "default": "test"
           },
           "namespace": {
             "anyOf": [
@@ -3116,9 +3315,9 @@
             ],
             "description": "Vector database to store the embeddings. If not provided, this comes from the env config.",
             "default": {
-              "type": "\"qdrant\" # only qdrant currently supported",
+              "type": "qdrant",
               "config": {
-                "api_key": "\"123456789\" # change this to something secure",
+                "api_key": "123456789",
                 "host": "http://localhost:6333"
               }
             }
@@ -3136,9 +3335,10 @@
             "default": {
               "summarize": false,
               "encoder": {
-                "dimensions": 1536,
+                "dimensions": "1536",
                 "encoder_model": "text-embedding-3-small",
-                "provider": "openai"
+                "provider": "openai",
+                "score_threshold": 0.5
               },
               "unstructured": {
                 "hi_res_model_name": "detectron2_onnx",
@@ -3152,6 +3352,9 @@
                 "prefix_summary": true,
                 "prefix_titles": true,
                 "rolling_window_size": 1
+              },
+              "parser_config": {
+                "structured_data_content_field": "page_content"
               }
             }
           },
@@ -3169,7 +3372,9 @@
           }
         },
         "type": "object",
-        "required": ["files"],
+        "required": [
+          "files"
+        ],
         "title": "IngestRequestPayload"
       },
       "JWTResponse": {
@@ -3180,7 +3385,9 @@
           }
         },
         "type": "object",
-        "required": ["token"],
+        "required": [
+          "token"
+        ],
         "title": "JWTResponse"
       },
       "LLMType": {
@@ -3188,6 +3395,7 @@
         "enum": [
           "GPT 4o Mini",
           "GPT 4",
+          "GPT 4 Turbo",
           "GPT 4o",
           "GPT 4 (Azure OpenAI)",
           "Anthropic Claude",
@@ -3262,13 +3470,36 @@
           }
         },
         "type": "object",
-        "required": ["strategy"],
+        "required": [
+          "strategy"
+        ],
         "title": "Login"
       },
       "Logout": {
-        "properties": {},
+        "properties": {
+
+        },
         "type": "object",
         "title": "Logout"
+      },
+      "ParserConfig": {
+        "properties": {
+          "structured_data_content_field": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Structured Data Content Field",
+            "description": "For JSON and CSV files: the field name containing the content to be embedded. All other fields will be saved as metadata.",
+            "default": "page_content"
+          }
+        },
+        "type": "object",
+        "title": "ParserConfig"
       },
       "QueryRequestPayload": {
         "properties": {
@@ -3312,7 +3543,7 @@
             ],
             "title": "Index Name",
             "description": "Name of the vector database follection to query from. If not provided, the `VECTOR_DB_COLLECTION_NAME` env var is used.",
-            "default": "documents"
+            "default": "test"
           },
           "vector_database": {
             "anyOf": [
@@ -3325,9 +3556,9 @@
             ],
             "description": "Vector database to query from. If not provided, this comes from the env config.",
             "default": {
-              "type": "\"qdrant\" # only qdrant currently supported",
+              "type": "qdrant",
               "config": {
-                "api_key": "\"123456789\" # change this to something secure",
+                "api_key": "123456789",
                 "host": "http://localhost:6333"
               }
             }
@@ -3345,7 +3576,8 @@
             "default": {
               "provider": "openai",
               "encoder_model": "text-embedding-3-small",
-              "dimensions": 1536
+              "dimensions": "1536",
+              "score_threshold": 0.5
             }
           },
           "enable_rerank": {
@@ -3391,7 +3623,9 @@
           }
         },
         "type": "object",
-        "required": ["input"],
+        "required": [
+          "input"
+        ],
         "title": "QueryRequestPayload"
       },
       "QueryResponsePayload": {
@@ -3409,7 +3643,10 @@
           }
         },
         "type": "object",
-        "required": ["success", "data"],
+        "required": [
+          "success",
+          "data"
+        ],
         "title": "QueryResponsePayload"
       },
       "RunnableConfig": {
@@ -3428,10 +3665,14 @@
           "callbacks": {
             "anyOf": [
               {
-                "items": {},
+                "items": {
+
+                },
                 "type": "array"
               },
-              {},
+              {
+
+              },
               {
                 "type": "null"
               }
@@ -3485,14 +3726,19 @@
           }
         },
         "type": "object",
-        "required": ["configurable"],
+        "required": [
+          "configurable"
+        ],
         "title": "RunnableConfigurableAlternativesConfig"
       },
       "SplitterConfig": {
         "properties": {
           "name": {
             "type": "string",
-            "enum": ["semantic", "by_title"],
+            "enum": [
+              "semantic",
+              "by_title"
+            ],
             "title": "Name",
             "description": "Splitter method",
             "default": "semantic"
@@ -3595,7 +3841,12 @@
           }
         },
         "type": "object",
-        "required": ["id", "user_id", "created_at", "updated_at"],
+        "required": [
+          "id",
+          "user_id",
+          "created_at",
+          "updated_at"
+        ],
         "title": "Thread"
       },
       "ThreadPostRequest": {
@@ -3629,7 +3880,9 @@
           }
         },
         "type": "object",
-        "required": ["values"],
+        "required": [
+          "values"
+        ],
         "title": "ThreadPostRequest",
         "description": "Payload for adding state to a thread."
       },
@@ -3657,33 +3910,105 @@
           }
         },
         "type": "object",
-        "required": ["thread_id"],
+        "required": [
+          "thread_id"
+        ],
         "title": "TitleRequest"
       },
-      "Tools": {
-        "type": "string",
-        "enum": [
-          "DDG Search",
-          "Search (Tavily)",
-          "Search (short answer, Tavily)",
-          "Retrieval",
-          "Arxiv",
-          "PubMed",
-          "Wikipedia"
+      "Tool": {
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AvailableTools"
+              }
+            ],
+            "title": "Tool Type",
+            "description": "The type of tool as defined by the AvailableTools enum."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Description",
+            "description": "A brief description of the tool."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Name",
+            "description": "The name of the tool."
+          },
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Configuration",
+            "description": "A field for additional configuration of the tool."
+          },
+          "multi_use": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Multi-Use",
+            "description": "Whether or not this is a multi-use tool.",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "description",
+          "name",
+          "config"
         ],
-        "title": "Tools"
+        "title": "Tool"
+      },
+      "ToolConfig": {
+        "properties": {
+
+        },
+        "type": "object",
+        "title": "ToolConfig"
       },
       "UnstructuredConfig": {
         "properties": {
           "partition_strategy": {
             "type": "string",
-            "enum": ["auto", "hi_res"],
+            "enum": [
+              "auto",
+              "hi_res"
+            ],
             "title": "Partition Strategy",
             "default": "auto"
           },
           "hi_res_model_name": {
             "type": "string",
-            "enum": ["detectron2_onnx", "chipper"],
+            "enum": [
+              "detectron2_onnx",
+              "chipper"
+            ],
             "title": "Hi Res Model Name",
             "description": "Only for `hi_res` strategy",
             "default": "detectron2_onnx"
@@ -3892,7 +4217,11 @@
           }
         },
         "type": "object",
-        "required": ["user_id", "created_at", "updated_at"],
+        "required": [
+          "user_id",
+          "created_at",
+          "updated_at"
+        ],
         "title": "User",
         "description": "Model representing a registered user in the application."
       },
@@ -3922,7 +4251,11 @@
           }
         },
         "type": "object",
-        "required": ["loc", "msg", "type"],
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
         "title": "ValidationError"
       },
       "VectorDatabase": {
@@ -3934,7 +4267,7 @@
               }
             ],
             "description": "Vector database type. Must be one of VectorDatabaseType enum.",
-            "default": "\"qdrant\" # only qdrant currently supported"
+            "default": "qdrant"
           },
           "config": {
             "type": "object",
@@ -3942,7 +4275,7 @@
             "description": "Vector database configuration object.",
             "default": {
               "host": "http://localhost:6333",
-              "api_key": "\"123456789\" # change this to something secure"
+              "api_key": "123456789"
             }
           }
         },
@@ -3951,7 +4284,9 @@
       },
       "VectorDatabaseType": {
         "type": "string",
-        "enum": ["qdrant"],
+        "enum": [
+          "qdrant"
+        ],
         "const": "qdrant",
         "title": "VectorDatabaseType"
       }


### PR DESCRIPTION
- Fixes Ollama embeddings issue
- #34 Adds support for JSON file upload
- #34 Adds support for CSV file upload
- Refactors and cleans up the embedding service
- Removes `filename` from file upload schema: specifying a preferred filename was a low-value feature that introduced complexity. Intention was to specify a preferred filename in the UI which would appear when the file was added to an assistant instead of the file name as it exists on the computer at time of upload but the functionality got overlooked in the frontend implementation, so I decided to remove it from the backend since it wasn't being used.
- Modifies the vector schema to move everything that isn't the namespace and embedded content to metadata, allowing for compatibility when external tools and vector databases are used with the platform.
- Allows score threshold to be set (see below)

**Schema Changes**
- For JSON and CSV file Upload, there is a new `parser_config` in the IngestRequestPayload schema that contains a `structured_data_content_field`. When the file contents are looped through, the contents of structured_data_content_field is sent through the ingestion pipeline and all other fields for the respective object are automatically added as chunk metadata
- The EncoderConfig now include score_threshold, allowing for the score threshold of retrieved results to be modified. This is reflected as an optional field in the encoder config portion of the ingest and query APIs. 