### PR TITLE
PF-221: Implement ingestion status API

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,19 @@
+name: PersonaFlow
 services:
-  stack:
-    image: personaflow/stack:latest
-    container_name: stack
-    # restart: on-failure
-    ports:
-      - "9000:9000"
-    networks:
-      - net
-    env_file:
-      - .env.production
+  # stack:
+  #   image: personaflow/stack:latest
+  #   container_name: stack
+  #   # restart: on-failure
+  #   ports:
+  #     - "9000:9000"
+  #   networks:
+  #     - net
+  #   env_file:
+  #     - .env.production
+  #   depends_on:
+  #     - redis
+  #     - qdrant
+  #     - postgres-db
   postgres-db:
     # Use a custom Docker build context for PostgreSQL.
     build: ./contrib/postgresql
@@ -57,6 +62,21 @@ services:
       - 8000:8000
     networks:
       - net
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   # langfuse-server:
   #   image: langfuse/langfuse:latest
   #   container_name: langfuse
@@ -113,6 +133,8 @@ volumes:
   postgresql_data:
     driver: local
   langfuse_data:
+    driver: local
+  redis_data:
     driver: local
   # models:
   #   driver: local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-name: PersonaFlow
+name: personaflow
 services:
   # stack:
   #   image: personaflow/stack:latest

--- a/stack/app/api/v1/rag.py
+++ b/stack/app/api/v1/rag.py
@@ -1,7 +1,9 @@
-from uuid import UUID
-import asyncio
+from uuid import UUID, uuid4
+from typing import List, Optional
 import aiohttp
-from fastapi import APIRouter, Depends, status
+import asyncio
+from redis.asyncio import Redis
+from fastapi import APIRouter, Depends, BackgroundTasks, Query
 from fastapi.exceptions import HTTPException
 from stack.app.core.auth.request_validators import AuthenticatedUser
 from stack.app.schema.rag import (
@@ -19,9 +21,12 @@ from stack.app.repositories.file import FileRepository, get_file_repository
 from stack.app.schema.file import FileSchema
 import structlog
 from stack.app.rag.custom_retriever import Retriever
-from stack.app.rag.ingest import get_ingest_tasks_from_config
-from stack.app.schema.rag import ContextType
+
+# from stack.app.rag.ingest import get_ingest_tasks_from_config
+from stack.app.schema.rag import BaseDocumentChunk
 from stack.app.schema.assistant import Assistant
+from stack.app.core.datastore import get_redis_connection
+from stack.app.rag.embedding_service import EmbeddingService
 
 
 logger = structlog.get_logger()
@@ -31,26 +36,247 @@ router = APIRouter()
 DEFAULT_TAG = "RAG"
 
 
-async def handle_assistant_files(
-    payload: IngestRequestPayload, assistant_repository: AssistantRepository
-) -> tuple[list[str], set[str], Assistant]:
-    assistant = await assistant_repository.retrieve_assistant(payload.namespace)
-    if assistant is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Assistant with ID {payload.namespace} not found.",
+async def prepare_files(
+    redis: Redis,
+    ingestion_id: str,
+    payload: IngestRequestPayload,
+    file_repository: FileRepository,
+    assistant_repository: AssistantRepository,
+) -> tuple[Optional[list[tuple[FileSchema, bytes]]], bool]:
+    try:
+        files_to_ingest = []
+        is_assistant = payload.purpose == "assistants"
+        if is_assistant:
+            assistant = await assistant_repository.retrieve_assistant(
+                UUID(payload.namespace)
+            )
+            if not assistant:
+                raise ValueError(f"Assistant with ID {payload.namespace} not found.")
+            existing_file_ids: set = set(assistant.file_ids or [])
+            new_file_ids = set(str(file_id) for file_id in payload.files) - set(
+                existing_file_ids
+            )
+            if not new_file_ids:
+                await redis.set(f"ingestion:{ingestion_id}:status", "completed")
+                await redis.set(
+                    f"ingestion:{ingestion_id}:message", "No new files to ingest."
+                )
+                return None, is_assistant
+            payload.files = list(new_file_ids)
+
+        total_files = len(payload.files)
+        for index, file_id in enumerate(payload.files, start=1):
+            await redis.rpush(
+                f"ingestion:{ingestion_id}:progress",
+                f"Retrieving file {index}/{total_files}",
+            )
+            file_model = await file_repository.retrieve_file(file_id)
+            file = FileSchema.model_validate(file_model)
+            file_content = await file_repository.retrieve_file_content(str(file_id))
+            files_to_ingest.append((file, file_content))
+            await redis.rpush(
+                f"ingestion:{ingestion_id}:progress",
+                f"Retrieved file {index}/{total_files}: {file.filename}",
+            )
+
+        return files_to_ingest, is_assistant
+    except Exception as e:
+        logger.exception(f"Error in prepare_files: {str(e)}")
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress", f"Error preparing files: {str(e)}"
+        )
+        raise
+
+
+async def generate_chunks_and_summaries(
+    redis: Redis,
+    ingestion_id: str,
+    embedding_service: EmbeddingService,
+    payload: IngestRequestPayload,
+) -> tuple[list[BaseDocumentChunk], list[BaseDocumentChunk] | None]:
+    try:
+        chunks = await embedding_service.generate_chunks(
+            payload.document_processor
+        )
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress", f"Generated {len(chunks)} chunks"
         )
 
-    existing_file_ids = set(assistant.file_ids or [])
-    new_file_ids = set(str(file_id) for file_id in payload.files) - existing_file_ids
+        summary_documents = None
+        if payload.document_processor and payload.document_processor.summarize:
+            await redis.rpush(
+                f"ingestion:{ingestion_id}:progress", "Generating summaries"
+            )
+            summary_documents = await embedding_service.generate_summary_documents(
+                chunks
+            )
+            await redis.rpush(
+                f"ingestion:{ingestion_id}:progress",
+                f"Generated {len(summary_documents)} summaries",
+            )
 
-    if not new_file_ids:
-        raise HTTPException(
-            status_code=status.HTTP_200_OK,
-            detail="No new files to ingest.",
+        return chunks, summary_documents
+    except Exception as e:
+        logger.exception(f"Error in generate_chunks_and_summaries: {str(e)}")
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress",
+            f"Error generating chunks and summaries: {str(e)}",
+        )
+        raise
+
+
+async def embed_and_upsert(
+    redis: Redis,
+    ingestion_id: str,
+    embedding_service: EmbeddingService,
+    payload: IngestRequestPayload,
+    chunks: List[dict],
+    summary_documents: Optional[List[dict]],
+) -> None:
+    try:
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress", "Embedding and upserting documents"
+        )
+        await embedding_service.embed_and_upsert(
+            chunks=chunks,
+            encoder=payload.document_processor.encoder.get_encoder() if payload.document_processor else None,
+            index_name=payload.index_name,
+        )
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress",
+            "Completed embedding and upserting chunks",
         )
 
-    return list(new_file_ids), existing_file_ids, assistant
+        if summary_documents:
+            await redis.rpush(
+                f"ingestion:{ingestion_id}:progress",
+                "Embedding and upserting summaries",
+            )
+            await embedding_service.embed_and_upsert(
+                chunks=summary_documents,
+                encoder=payload.document_processor.encoder.get_encoder(),
+                index_name=f"{payload.index_name}_summary",
+            )
+            await redis.rpush(
+                f"ingestion:{ingestion_id}:progress",
+                "Completed embedding and upserting summaries",
+            )
+    except Exception as e:
+        logger.exception(f"Error in embed_and_upsert: {str(e)}")
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress",
+            f"Error embedding and upserting: {str(e)}",
+        )
+        raise
+
+
+async def update_assistant(
+    redis: Redis,
+    ingestion_id: str,
+    assistant_repository: AssistantRepository,
+    assistant: dict,
+    payload: IngestRequestPayload,
+) -> None:
+    try:
+        await redis.rpush(f"ingestion:{ingestion_id}:progress", "Updating assistant")
+        existing_file_ids = set(assistant.get("file_ids", []))
+        updated_file_ids = list(existing_file_ids | set(payload.files))
+        await assistant_repository.update_assistant(
+            assistant.id, {"file_ids": updated_file_ids}
+        )
+        await redis.rpush(f"ingestion:{ingestion_id}:progress", "Assistant updated")
+    except Exception as e:
+        logger.exception(f"Error in update_assistant: {str(e)}")
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress", f"Error updating assistant: {str(e)}"
+        )
+        raise
+
+
+async def notify_webhook(
+    webhook_url: str, collection_name: str, namespace: str, file_ids: List[str]
+) -> None:
+    try:
+        async with aiohttp.ClientSession() as session:
+            await session.post(
+                url=webhook_url,
+                json={
+                    "index_name": collection_name,
+                    "status": "completed",
+                    "namespace": namespace,
+                    "file_ids": file_ids,
+                },
+            )
+    except Exception as e:
+        logger.exception(f"Error in notify_webhook: {str(e)}")
+        # We don't re-raise this exception as it's not critical to the ingestion process
+
+
+async def process_ingestion(
+    ingestion_id: str,
+    payload: IngestRequestPayload,
+    file_repository: FileRepository,
+    assistant_repository: AssistantRepository,
+    test_delay: float = 0,
+) -> None:
+    redis = await get_redis_connection()
+    try:
+        await redis.set(f"ingestion:{ingestion_id}:status", "started")
+
+        files_to_ingest, is_assistant = await prepare_files(
+            redis, ingestion_id, payload, file_repository, assistant_repository
+        )
+        if files_to_ingest is None:
+            return
+
+        embedding_service = EmbeddingService(
+            index_name=payload.index_name,
+            encoder=payload.document_processor.encoder.get_encoder(),
+            vector_credentials=payload.vector_database,
+            dimensions=payload.document_processor.encoder.dimensions if payload.document_processor else None,
+            files=files_to_ingest,
+            namespace=payload.namespace,
+            purpose=payload.purpose,
+            parser_config=payload.document_processor.parser_config if payload.document_processor else None,
+            redis=redis,
+            ingestion_id=ingestion_id,
+            test_delay=test_delay,
+        )
+
+        chunks, summary_documents = await generate_chunks_and_summaries(
+            redis, ingestion_id, embedding_service, payload
+        )
+
+        await embed_and_upsert(
+            redis, ingestion_id, embedding_service, payload, chunks, summary_documents
+        )
+
+        if is_assistant:
+            assistant = await assistant_repository.retrieve_assistant(payload.namespace)
+            await update_assistant(
+                redis, ingestion_id, assistant_repository, assistant, payload
+            )
+
+        if payload.webhook_url:
+            await notify_webhook(
+                payload.webhook_url,
+                payload.index_name,
+                payload.namespace,
+                payload.files,
+            )
+
+        await redis.set(f"ingestion:{ingestion_id}:status", "completed")
+        await redis.rpush(
+            f"ingestion:{ingestion_id}:progress",
+            "Ingestion process completed successfully",
+        )
+
+    except Exception as e:
+        logger.exception(f"Error during ingestion process: {str(e)}")
+        await redis.set(f"ingestion:{ingestion_id}:status", "failed")
+        await redis.rpush(f"ingestion:{ingestion_id}:progress", f"Error: {str(e)}")
+    finally:
+        await redis.close()
 
 
 @router.post(
@@ -64,72 +290,164 @@ async def handle_assistant_files(
 async def ingest(
     auth: AuthenticatedUser,
     payload: IngestRequestPayload,
+    background_tasks: BackgroundTasks,
+    test_delay: float = Query(0, description="Introduces a delay in seconds for each step of the ingestion process for testing purposes."),
     file_repository: FileRepository = Depends(get_file_repository),
     assistant_repository: AssistantRepository = Depends(get_assistant_repository),
 ) -> dict:
-    files_to_ingest = []
     try:
-        is_assistant = payload.purpose == ContextType.assistants
-        existing_file_ids = set()
-        assistant = None
-
-        if is_assistant:
-            payload.files, existing_file_ids, assistant = await handle_assistant_files(
-                payload, assistant_repository
-            )
-
-        for file_id in payload.files:
-            file_model = await file_repository.retrieve_file(file_id)
-            file = FileSchema.model_validate(file_model)
-            file_content = await file_repository.retrieve_file_content(str(file_id))
-            files_to_ingest.append((file, file_content))
-
-        tasks = await get_ingest_tasks_from_config(files_to_ingest, payload)
-
-        await asyncio.gather(*tasks)
-
-        if is_assistant and assistant:
-            updated_file_ids = list(existing_file_ids | set(payload.files))
-            await assistant_repository.update_assistant(
-                assistant.id, {"file_ids": updated_file_ids}
-            )
-
-        if payload.webhook_url:
-            await notify_webhook(
-                payload.webhook_url,
-                payload.index_name,
-                payload.namespace,
-                payload.files,
-            )
-
-        return {
-            "success": True,
-            "message": f"Ingested {len(files_to_ingest)} new files.",
-        }
-    except HTTPException as he:
-        # Re-raise HTTP exceptions
-        raise he
+        ingestion_id = str(uuid4())
+        background_tasks.add_task(
+            process_ingestion,
+            ingestion_id,
+            payload,
+            file_repository,
+            assistant_repository,
+            test_delay,
+        )
+        return {"ingestion_id": ingestion_id, "status": "started"}
     except Exception as e:
-        logger.exception(f"Error ingesting files: {str(e)}")
+        logger.exception(f"Error starting ingestion process: {str(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="An error occurred while ingesting the files.",
+            status_code=500, detail=f"Error starting ingestion process: {str(e)}"
         )
 
 
-async def notify_webhook(
-    webhook_url: str, collection_name: str, namespace: str, file_ids: list[str]
-):
-    async with aiohttp.ClientSession() as session:
-        await session.post(
-            url=webhook_url,
-            json={
-                "index_name": collection_name,
-                "status": "completed",
-                "namespace": namespace,
-                "file_ids": file_ids,
-            },
-        )
+@router.get("/ingest/{ingestion_id}/progress", tags=[DEFAULT_TAG])
+async def ingest_progress(ingestion_id: str):
+    from sse_starlette.sse import EventSourceResponse
+    
+    async def event_generator():
+        redis = await get_redis_connection()
+        try:
+            logger.info(f"Starting event generator for ingestion {ingestion_id}")
+            while True:
+                # Consume all available messages
+                while True:
+                    message = await redis.lpop(f"ingestion:{ingestion_id}:progress")
+                    if message:
+                        logger.debug(f"Received progress message: {message.decode('utf-8')}")
+                        yield {"event": "progress", "data": message.decode("utf-8")}
+                    else:
+                        break  # No more messages available
+                
+                # Check status after consuming all available messages
+                status = await redis.get(f"ingestion:{ingestion_id}:status")
+                if status in [b"completed", b"failed"]:
+                    logger.info(f"Ingestion {ingestion_id} {status.decode('utf-8')}")
+                    yield {"event": "completed", "data": status.decode("utf-8")}
+                    break
+                
+                # Short sleep to prevent tight looping
+                await asyncio.sleep(0.1)
+        except Exception as e:
+            logger.exception(f"Error in event_generator: {str(e)}")
+            yield {"event": "error", "data": f"Error: {str(e)}"}
+        finally:
+            await redis.close()
+            logger.info(f"Event generator for ingestion {ingestion_id} finished")
+
+    return EventSourceResponse(event_generator())
+
+
+# async def handle_assistant_files(
+#     payload: IngestRequestPayload, assistant_repository: AssistantRepository
+# ) -> tuple[list[str], set[str], Assistant]:
+#     assistant = await assistant_repository.retrieve_assistant(payload.namespace)
+#     if assistant is None:
+#         raise HTTPException(
+#             status_code=status.HTTP_404_NOT_FOUND,
+#             detail=f"Assistant with ID {payload.namespace} not found.",
+#         )
+
+#     existing_file_ids = set(assistant.file_ids or [])
+#     new_file_ids = set(str(file_id) for file_id in payload.files) - existing_file_ids
+
+#     if not new_file_ids:
+#         raise HTTPException(
+#             status_code=status.HTTP_200_OK,
+#             detail="No new files to ingest.",
+#         )
+
+#     return list(new_file_ids), existing_file_ids, assistant
+
+# @router.post(
+#     "/ingest",
+#     tags=[DEFAULT_TAG],
+#     response_model=dict,
+#     operation_id="ingest_data_from_files",
+#     summary="Ingest files to be indexed and queried.",
+#     description="Upload files for ingesting using the advanced RAG system.",
+# )
+# async def ingest(
+#     auth: AuthenticatedUser,
+#     payload: IngestRequestPayload,
+#     file_repository: FileRepository = Depends(get_file_repository),
+#     assistant_repository: AssistantRepository = Depends(get_assistant_repository),
+# ) -> dict:
+#     files_to_ingest = []
+#     try:
+#         is_assistant = payload.purpose == ContextType.assistants
+#         existing_file_ids = set()
+#         assistant = None
+
+#         if is_assistant:
+#             payload.files, existing_file_ids, assistant = await handle_assistant_files(
+#                 payload, assistant_repository
+#             )
+
+#         for file_id in payload.files:
+#             file_model = await file_repository.retrieve_file(file_id)
+#             file = FileSchema.model_validate(file_model)
+#             file_content = await file_repository.retrieve_file_content(str(file_id))
+#             files_to_ingest.append((file, file_content))
+
+#         tasks = await get_ingest_tasks_from_config(files_to_ingest, payload)
+
+#         await asyncio.gather(*tasks)
+
+#         if is_assistant and assistant:
+#             updated_file_ids = list(existing_file_ids | set(payload.files))
+#             await assistant_repository.update_assistant(
+#                 assistant.id, {"file_ids": updated_file_ids}
+#             )
+
+#         if payload.webhook_url:
+#             await notify_webhook(
+#                 payload.webhook_url,
+#                 payload.index_name,
+#                 payload.namespace,
+#                 payload.files,
+#             )
+
+#         return {
+#             "success": True,
+#             "message": f"Ingested {len(files_to_ingest)} new files.",
+#         }
+#     except HTTPException as he:
+#         # Re-raise HTTP exceptions
+#         raise he
+#     except Exception as e:
+#         logger.exception(f"Error ingesting files: {str(e)}")
+#         raise HTTPException(
+#             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+#             detail="An error occurred while ingesting the files.",
+#         )
+
+
+# async def notify_webhook(
+#     webhook_url: str, collection_name: str, namespace: str, file_ids: list[str]
+# ):
+#     async with aiohttp.ClientSession() as session:
+#         await session.post(
+#             url=webhook_url,
+#             json={
+#                 "index_name": collection_name,
+#                 "status": "completed",
+#                 "namespace": namespace,
+#                 "file_ids": file_ids,
+#             },
+#         )
 
 
 @router.post(

--- a/stack/app/api/v1/rag.py
+++ b/stack/app/api/v1/rag.py
@@ -105,9 +105,7 @@ async def generate_chunks_and_summaries(
 
         summary_documents = None
         if payload.document_processor and payload.document_processor.summarize:
-            await redis_service.push_progress_message(
-                task_id, "Generating summaries"
-            )
+            await redis_service.push_progress_message(task_id, "Generating summaries")
             summary_documents = await embedding_service.generate_summary_documents(
                 chunks
             )
@@ -252,12 +250,12 @@ async def process_ingestion(
         )
 
         await embed_and_upsert(
-            task_id, 
-            embedding_service, 
-            payload, 
-            chunks, 
-            summary_documents, 
-            redis_service
+            task_id,
+            embedding_service,
+            payload,
+            chunks,
+            summary_documents,
+            redis_service,
         )
 
         if is_assistant:
@@ -322,7 +320,7 @@ async def ingest(
 
 
 @router.get(
-    "/ingest/{task_id}/progress", 
+    "/ingest/{task_id}/progress",
     tags=[DEFAULT_TAG],
     response_class=EventSourceResponse,
     operation_id="ingest_task_progress",

--- a/stack/app/core/configuration.py
+++ b/stack/app/core/configuration.py
@@ -113,6 +113,14 @@ class Settings(BaseSettings):
             f"@{self.INTERNAL_DATABASE_HOST}:{self.INTERNAL_DATABASE_PORT}/{self.INTERNAL_DATABASE_DATABASE}"
         )
 
+    # Redis Configuration
+    @property
+    def REDIS_URL(self) -> str:
+        if os.environ.get('DOCKER_ENV'):
+            return os.getenv("REDIS_URL", "redis://redis:6379")
+        else:
+            return os.getenv("REDIS_URL", "redis://localhost:6379")
+
     #  LLM Configurations
     OPENAI_PROXY_URL: Optional[str] = os.getenv("OPENAI_PROXY_URL", None)
     GPT_4_MODEL_NAME: Optional[str] = os.getenv(

--- a/stack/app/core/configuration.py
+++ b/stack/app/core/configuration.py
@@ -116,7 +116,7 @@ class Settings(BaseSettings):
     # Redis Configuration
     @property
     def REDIS_URL(self) -> str:
-        if os.environ.get('DOCKER_ENV'):
+        if os.environ.get("DOCKER_ENV"):
             return os.getenv("REDIS_URL", "redis://redis:6379")
         else:
             return os.getenv("REDIS_URL", "redis://localhost:6379")

--- a/stack/app/core/datastore.py
+++ b/stack/app/core/datastore.py
@@ -10,6 +10,7 @@ It integrates with the application configuration settings to fetch or create a n
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from redis.asyncio import Redis
 from sqlalchemy.orm import sessionmaker
 from stack.app.core.configuration import Settings, get_settings
 from typing import AsyncGenerator, Annotated, Any, Generator
@@ -32,3 +33,7 @@ def get_session() -> Generator[Session, Any, None]:
     engine = create_engine(Settings.INTERNAL_DATABASE_URI)
     with Session(engine) as session:
         yield session
+
+
+async def get_redis_connection():
+    return Redis.from_url("redis://localhost:6379")

--- a/stack/app/core/redis.py
+++ b/stack/app/core/redis.py
@@ -9,8 +9,12 @@ class RedisService:
     def __init__(self, redis: Redis):
         self.redis = redis
 
-    async def get_progress_messages(self, task_id: str, start_index: int = 0) -> list[str]:
-        messages = await self.redis.lrange(f"ingestion:{task_id}:progress", start_index, -1)
+    async def get_progress_messages(
+        self, task_id: str, start_index: int = 0
+    ) -> list[str]:
+        messages = await self.redis.lrange(
+            f"ingestion:{task_id}:progress", start_index, -1
+        )
         return [message.decode("utf-8") for message in messages]
 
     async def get_ingestion_status(self, task_id: str) -> Optional[str]:

--- a/stack/app/core/redis.py
+++ b/stack/app/core/redis.py
@@ -9,21 +9,21 @@ class RedisService:
     def __init__(self, redis: Redis):
         self.redis = redis
 
-    async def get_progress_messages(self, ingestion_id: str, start_index: int = 0) -> list[str]:
-        messages = await self.redis.lrange(f"ingestion:{ingestion_id}:progress", start_index, -1)
+    async def get_progress_messages(self, task_id: str, start_index: int = 0) -> list[str]:
+        messages = await self.redis.lrange(f"ingestion:{task_id}:progress", start_index, -1)
         return [message.decode("utf-8") for message in messages]
 
-    async def get_ingestion_status(self, ingestion_id: str) -> Optional[str]:
-        status = await self.redis.get(f"ingestion:{ingestion_id}:status")
+    async def get_ingestion_status(self, task_id: str) -> Optional[str]:
+        status = await self.redis.get(f"ingestion:{task_id}:status")
         if status:
             return status.decode("utf-8")
         return None
 
-    async def push_progress_message(self, ingestion_id: str, message: str):
-        await self.redis.rpush(f"ingestion:{ingestion_id}:progress", message)
+    async def push_progress_message(self, task_id: str, message: str):
+        await self.redis.rpush(f"ingestion:{task_id}:progress", message)
 
-    async def set_ingestion_status(self, ingestion_id: str, status: str):
-        await self.redis.set(f"ingestion:{ingestion_id}:status", status)
+    async def set_ingestion_status(self, task_id: str, status: str):
+        await self.redis.set(f"ingestion:{task_id}:status", status)
 
 
 async def get_redis_service() -> RedisService:

--- a/stack/app/core/redis.py
+++ b/stack/app/core/redis.py
@@ -9,11 +9,9 @@ class RedisService:
     def __init__(self, redis: Redis):
         self.redis = redis
 
-    async def get_progress_message(self, ingestion_id: str) -> Optional[str]:
-        message = await self.redis.lpop(f"ingestion:{ingestion_id}:progress")
-        if message:
-            return message.decode("utf-8")
-        return None
+    async def get_progress_messages(self, ingestion_id: str, start_index: int = 0) -> list[str]:
+        messages = await self.redis.lrange(f"ingestion:{ingestion_id}:progress", start_index, -1)
+        return [message.decode("utf-8") for message in messages]
 
     async def get_ingestion_status(self, ingestion_id: str) -> Optional[str]:
         status = await self.redis.get(f"ingestion:{ingestion_id}:status")

--- a/stack/app/core/redis.py
+++ b/stack/app/core/redis.py
@@ -1,0 +1,35 @@
+from redis.asyncio import Redis
+import structlog
+from typing import Optional
+
+logger = structlog.get_logger()
+
+
+class RedisService:
+    def __init__(self, redis: Redis):
+        self.redis = redis
+
+    async def get_progress_message(self, ingestion_id: str) -> Optional[str]:
+        message = await self.redis.lpop(f"ingestion:{ingestion_id}:progress")
+        if message:
+            return message.decode("utf-8")
+        return None
+
+    async def get_ingestion_status(self, ingestion_id: str) -> Optional[str]:
+        status = await self.redis.get(f"ingestion:{ingestion_id}:status")
+        if status:
+            return status.decode("utf-8")
+        return None
+
+    async def push_progress_message(self, ingestion_id: str, message: str):
+        await self.redis.rpush(f"ingestion:{ingestion_id}:progress", message)
+
+    async def set_ingestion_status(self, ingestion_id: str, status: str):
+        await self.redis.set(f"ingestion:{ingestion_id}:status", status)
+
+
+async def get_redis_service() -> RedisService:
+    from stack.app.core.datastore import get_redis_connection
+
+    redis = await get_redis_connection()
+    return RedisService(redis)

--- a/stack/app/rag/embedding_service.py
+++ b/stack/app/rag/embedding_service.py
@@ -145,9 +145,8 @@ class EmbeddingService:
                 max_density_word_count=self.MAX_DENSITY_WORD_COUNT,
             )
             if not valid:
-                logger.debug(f"Filtering out chunk, {reason}, {chunk}")
+                logger.debug(f"Filtering out chunk, {reason}")
                 continue
-            logger.debug(f"Chunk is useful: {chunk}")
             document_content += chunk_content
             filtered_chunks.append(chunk)
 

--- a/stack/app/rag/embedding_service.py
+++ b/stack/app/rag/embedding_service.py
@@ -73,7 +73,7 @@ class EmbeddingService:
         purpose: Optional[str] = None,
         parser_config: Optional[ParserConfig] = None,
         redis_service: Optional[RedisService] = None,
-        ingestion_id: Optional[str] = None,
+        task_id: Optional[str] = None,
     ):
         self.encoder = encoder
         self.files = files
@@ -88,16 +88,16 @@ class EmbeddingService:
         )
         self.parser_config = parser_config or ParserConfig()
         self.redis_service = redis_service
-        self.ingestion_id = ingestion_id
+        self.task_id = task_id
 
     async def _report_progress(self, message: str):
-        if self.redis_service and self.ingestion_id:
+        if self.redis_service and self.task_id:
             logger.debug(
-                f"Reporting progress update for {self.ingestion_id}: {message}"
+                f"Reporting progress update for {self.task_id}: {message}"
             )
-            await self.redis_service.push_progress_message(self.ingestion_id, message)
+            await self.redis_service.push_progress_message(self.task_id, message)
         else:
-            logger.info(f"Progress update for {self.ingestion_id}: {message}")
+            logger.info(f"Progress update for {self.task_id}: {message}")
 
     async def generate_chunks(
         self, config: DocumentProcessorConfig
@@ -303,17 +303,17 @@ class EmbeddingService:
         encoder: BaseEncoder,
         index_name: Optional[str] = None,
         batch_size: int = 100,
-        ingestion_id: Optional[str] = None,
+        task_id: Optional[str] = None,
         redis_service: Optional[RedisService] = None,
     ) -> list[BaseDocumentChunk]:
         _redis_service = redis_service or self.redis_service
-        _ingestion_id = ingestion_id or self.ingestion_id
+        _task_id = task_id or self.task_id
 
         total_chunks = len(chunks)
 
-        if _redis_service and _ingestion_id:
+        if _redis_service and _task_id:
             await _redis_service.push_progress_message(
-                _ingestion_id,
+                _task_id,
                 f"Starting embedding process for {total_chunks} chunks...",
             )
 

--- a/stack/app/rag/embedding_service.py
+++ b/stack/app/rag/embedding_service.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 import uuid
 from typing import Any, Literal, Optional, Tuple
-
+from redis.asyncio import Redis
 import numpy as np
 import structlog
 from semantic_router.encoders import (
@@ -70,10 +70,13 @@ class EmbeddingService:
         encoder: BaseEncoder,
         vector_credentials: dict,
         dimensions: Optional[int],
-        files: Optional[list[tuple[FileSchema, bytes]]] = None,
+        files: list[tuple[FileSchema, bytes]] = None,
         namespace: Optional[str] = None,
         purpose: Optional[str] = None,
         parser_config: Optional[ParserConfig] = None,
+        redis: Optional[Redis] = None,
+        ingestion_id: Optional[str] = None,
+        test_delay: float = 0,
     ):
         self.encoder = encoder
         self.files = files
@@ -87,21 +90,53 @@ class EmbeddingService:
             server_url=settings.UNSTRUCTURED_BASE_URL,
         )
         self.parser_config = parser_config or ParserConfig()
+        self.redis = redis
+        self.ingestion_id = ingestion_id 
+        self.test_delay = test_delay
+
+    async def _simulate_delay(self):
+        if self.test_delay > 0:
+            await asyncio.sleep(self.test_delay)
+            # await self._report_progress(f"Simulated delay of {self.test_delay} seconds")
+
+
+    async def _report_progress(self, message: str):
+        if self.redis and self.ingestion_id:
+            await self.redis.rpush(f"ingestion:{self.ingestion_id}:progress", message)
+        # if self.test_delay > 0:
+        #     await self._simulate_delay()
+        else:
+            logger.info(f"Progress update for {self.ingestion_id}: {message}")
+
 
     async def generate_chunks(
         self, config: DocumentProcessorConfig
     ) -> list[BaseDocumentChunk]:
-        logger.info(f"Generating chunks using method: {config.splitter.name}")
-        doc_chunks = []
-        for file, file_content in tqdm(self.files, desc="Generating chunks"):
+        logger.debug(f"Generating chunks using method: {config.splitter.name}")
+
+        doc_chunks: list[BaseDocumentChunk] = []
+
+        if self.files is None:
+            logger.warning("No files to process")
+            await self._report_progress("No files to process")
+            return doc_chunks
+
+        total_files = len(self.files)
+        for index, (file, file_content) in enumerate(self.files, start=1):
             try:
+                await self._report_progress(
+                    f"Processing file {index}/{total_files}: {file.filename}",
+                )
                 chunks = await self._process_file(file, file_content, config)
                 filtered_chunks = self._filter_chunks(chunks)
                 doc_chunks.extend(filtered_chunks)
+                await self._report_progress(f"Processed file {index}/{total_files}: {file.filename}")
             except Exception as e:
                 logger.error(f"Error loading chunks for file {file.filename}: {e}")
+                await self._report_progress(f"Error processing file {file.filename}: {str(e)}")
                 raise
         return doc_chunks
+
 
     def _filter_chunks(
         self, chunks: list[BaseDocumentChunk]
@@ -277,6 +312,8 @@ class EmbeddingService:
         index_name: Optional[str] = None,
         batch_size: int = 100,
     ) -> list[BaseDocumentChunk]:
+        total_chunks = len(chunks)
+        await self._report_progress(f"Starting embedding process for {total_chunks} chunks...")
         pbar = tqdm(total=len(chunks), desc="Generating embeddings")
         queue = asyncio.Queue()
 
@@ -296,6 +333,7 @@ class EmbeddingService:
                 for chunk, embedding in zip(chunks_batch, embeddings):
                     chunk.dense_embedding = np.array(embedding).tolist()
                 pbar.update(len(chunks_batch))
+                await self._report_progress(f"Embedded {pbar.n}/{total_chunks} chunks ({pbar.n/total_chunks:.2%})")
                 return chunks_batch
             except Exception as e:
                 logger.error(f"Error embedding a batch of documents: {e}")
@@ -325,9 +363,11 @@ class EmbeddingService:
         ]
         pbar.close()
 
-        print(f"Attempting to upsert {len(chunks_with_embeddings)} chunks...")
+        await self._report_progress(f"Embedding completed. Starting upsert for {len(chunks_with_embeddings)} chunks...")
+
         if not chunks_with_embeddings:
             logger.warn("No chunks to upsert. Aborting operation.")
+            await self._report_progress("No chunks to upsert. Aborting operation.")
             return []
 
         vector_service = get_vector_service(
@@ -337,11 +377,17 @@ class EmbeddingService:
             dimensions=self.dimensions,
         )
         try:
-            await vector_service.upsert(chunks=chunks_with_embeddings)
+            total_chunks = len(chunks_with_embeddings)
+            for i in range(0, total_chunks, batch_size):
+                batch = chunks_with_embeddings[i:i+batch_size]
+                await vector_service.upsert(chunks=batch)
+                await self._report_progress(f"Upserted {min(i+batch_size, total_chunks)}/{total_chunks} chunks ({min(i+batch_size, total_chunks)/total_chunks:.2%})")
         except Exception as e:
             logger.error(f"Error upserting embeddings: {e}")
+            await self._report_progress(f"Error upserting embeddings: {str(e)}")
             raise
-
+        
+        await self._report_progress("Upsert completed.")
         return chunks_with_embeddings
 
     async def generate_summary_documents(

--- a/stack/app/rag/embedding_service.py
+++ b/stack/app/rag/embedding_service.py
@@ -92,9 +92,7 @@ class EmbeddingService:
 
     async def _report_progress(self, message: str):
         if self.redis_service and self.task_id:
-            logger.debug(
-                f"Reporting progress update for {self.task_id}: {message}"
-            )
+            logger.debug(f"Reporting progress update for {self.task_id}: {message}")
             await self.redis_service.push_progress_message(self.task_id, message)
         else:
             logger.info(f"Progress update for {self.task_id}: {message}")

--- a/stack/app/utils/stream.py
+++ b/stack/app/utils/stream.py
@@ -13,8 +13,10 @@ logger = structlog.get_logger(__name__)
 
 MessagesStream = AsyncIterator[Union[list[AnyMessage], str]]
 
+
 async def ingest_task_event_generator(task_id: str, redis_service: RedisService):
-    """Generator function to stream data ingestion task events to the client."""
+    """Generator function to stream data ingestion task events to the
+    client."""
     logger.info(f"Starting event generator for ingestion {task_id}")
     last_index = 0
     try:
@@ -22,7 +24,7 @@ async def ingest_task_event_generator(task_id: str, redis_service: RedisService)
             "event": "metadata",
             "data": orjson.dumps({"task_id": task_id}).decode(),
         }
-        
+
         while True:
             messages = await redis_service.get_progress_messages(task_id, last_index)
             for message in messages:
@@ -32,7 +34,7 @@ async def ingest_task_event_generator(task_id: str, redis_service: RedisService)
                     "data": orjson.dumps({"progress": message}).decode(),
                 }
                 last_index += 1
-            
+
             status = await redis_service.get_ingestion_status(task_id)
             if status in ["completed", "failed"]:
                 logger.debug(f"Sending completion event: {status}")
@@ -41,7 +43,7 @@ async def ingest_task_event_generator(task_id: str, redis_service: RedisService)
                     "data": orjson.dumps({"status": status}).decode(),
                 }
                 break
-            
+
             if not messages:
                 await asyncio.sleep(0.5)  # Wait a bit before checking again
     except Exception as e:


### PR DESCRIPTION
Implements a new API at /rag/ingest/{task_id}/progress

There is an issue where the backend streams all of the events in when the ingestion process has finished that still needs to be resolved, but its enough for the UI to implement.

Test steps:

1. in postman, call the /ingest api with a couple of files using the semantic chunking method so it takes some time to run. This will return:
{
    "task_id": "994bc452-09aa-4690-8673-dc9282c20d91",
    "status": "started"
}

2. Copy the task_id and open a terminal and paste in the following: `curl  http://localhost:9000/api/v1/rag/ingest/{task_id}/progress`

It will take a few seconds due to the issue of it not streaming the events until after flow completes, but you should see:
```
event: metadata
data: {"ingestion_id":"c96981c9-5d5b-4afb-a1e5-b41b9d912d74"}

event: data
data: {"progress":"Retrieving file 1/2"}

event: data
data: {"progress":"Retrieved file 1/2: llm-as-judge.pdf"}

event: data
data: {"progress":"Retrieving file 2/2"}

event: data
data: {"progress":"Retrieved file 2/2: small.json"}

event: data
data: {"progress":"Generating chunks"}

event: data
data: {"progress":"Processing file 1/2: llm-as-judge.pdf"}

event: data
data: {"progress":"Processing file 2/2: small.json"}

event: data
data: {"progress":"Generated 421 chunks"}

(...)

event: data
data: {"status":"completed"}

event: end

```

Note: make sure to use the semantic splitting method which takes a little longer to run, otherwise by the time you make the second request the process may be finished.



