### PR TITLE
(PersonaFlow-122) Bug: Remove configSchema from assistant creation

### DIFF
--- a/ui/src/components/features/build-panel/components/create-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/create-assistant.tsx
@@ -47,6 +47,7 @@ export function CreateAssistant() {
   const architectureType = form.watch("config.configurable.type");
   const tools = form.watch("config.configurable.tools");
 
+  // Only use config schema as defaults - don't use in edit
   const { systemMessage, retrievalDescription } = useConfigSchema(
     architectureType ?? "",
   );

--- a/ui/src/components/features/build-panel/components/edit-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/edit-assistant.tsx
@@ -58,10 +58,6 @@ function EditAssistantForm({
 
   const { toast } = useToast();
 
-  const { systemMessage, retrievalDescription } = useConfigSchema(
-    architectureType ?? "",
-  );
-
   const { availableTools } = useAvailableTools();
 
   useEffect(() => {
@@ -69,18 +65,6 @@ function EditAssistantForm({
       form.reset(selectedAssistant);
     }
   }, [selectedAssistant]);
-
-  useEffect(() => {
-    if (architectureType) {
-      // @ts-ignore
-      form.setValue("config.configurable.system_message", systemMessage);
-      form.setValue(
-        "config.configurable.retrieval_description",
-        // @ts-ignore
-        retrievalDescription,
-      );
-    }
-  }, [architectureType]);
 
   useEffect(() => {
     if (architectureType !== "agent") {

--- a/ui/src/components/features/build-panel/components/files-dialog.tsx
+++ b/ui/src/components/features/build-panel/components/files-dialog.tsx
@@ -194,7 +194,7 @@ export default function FilesDialog({ form, classNames }: TFilesDialog) {
             </Button>
           </DialogClose>
         </DialogFooter>
-      </DialogContent>
+``      </DialogContent>
     </Dialog>
   );
 }


### PR DESCRIPTION
On assistant update, retrieval_description and system_message were being populated with default values from config schema rather than the previously submitted text. We only want to use the config schema as default values for assistant creation, when fields are empty.

https://github.com/user-attachments/assets/8764769c-ce88-48c1-a9cf-93b77a3ca2e4

