### PR TITLE
bug (PersonaFlow-234): `agent_type` default value is being lost

### DIFF
--- a/ui/src/components/features/build-panel/components/assistant-form.tsx
+++ b/ui/src/components/features/build-panel/components/assistant-form.tsx
@@ -35,7 +35,10 @@ export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
 
   const {
     formState: { isDirty },
+    getValues
   } = form;
+
+  console.log(getValues());
 
   if (isLoading) return <Spinner />;
 
@@ -89,7 +92,7 @@ export function AssistantForm({ form, onSubmit }: TAssistantFormProps) {
                       (config?.definitions.AgentType as TSchemaField).enum ?? []
                     }
                     formName="config.configurable.agent_type"
-                    title="Agent type"
+                    title="Language Model"
                     placeholder="Select agent type"
                   />
                 ) : (

--- a/ui/src/components/features/build-panel/components/create-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/create-assistant.tsx
@@ -41,8 +41,10 @@ export function CreateAssistant() {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: defaultValues,
+    defaultValues,
   });
+  console.log(defaultValues);
+  console.log('inside create',form.getValues())
 
   const architectureType = form.watch("config.configurable.type");
   const tools = form.watch("config.configurable.tools");
@@ -68,7 +70,7 @@ export function CreateAssistant() {
   }, [architectureType]);
 
   useEffect(() => {
-    if (architectureType !== "agent") {
+    if (architectureType && architectureType !== "agent") {
       // Unregister agent_type
       form.unregister("config.configurable.agent_type");
     }

--- a/ui/src/components/features/build-panel/components/create-assistant.tsx
+++ b/ui/src/components/features/build-panel/components/create-assistant.tsx
@@ -13,6 +13,9 @@ import { useToast } from "@/components/ui/use-toast";
 import { useRouter } from "next/navigation";
 import { SquarePlus } from "lucide-react";
 
+const DEFAULT_agent_type = "GPT 4o Mini";
+const DEFAULT_llm_type = "GPT 4o Mini";
+
 const defaultValues = {
   public: false,
   name: "",
@@ -20,8 +23,8 @@ const defaultValues = {
     configurable: {
       interrupt_before_action: false,
       type: "",
-      agent_type: "GPT 4o Mini",
-      llm_type: "GPT 4o Mini",
+      agent_type: DEFAULT_agent_type,
+      llm_type: DEFAULT_llm_type,
       retrieval_description: "",
       system_message: "",
       tools: [],


### PR DESCRIPTION
### Issue
`agent_type` default value was being lost on assistant creation and as a result was allowing a user to create an assistant without an `agent_type`, and causing future bugs.

This happened because there's a `useEffect` that unregisters `agent_type` if another `architectureType` is selected other than `agent` - and it was unregistering on initial render because initially there is no architecturalType.


https://github.com/user-attachments/assets/45b28154-14dd-40d6-bc11-1e0f7583a434

