### PR TITLE
improve  navbar

### DIFF
--- a/ui/src/components/features/navbar/components/navbar.tsx
+++ b/ui/src/components/features/navbar/components/navbar.tsx
@@ -19,7 +19,7 @@ export default function Navbar() {
 
   const router = useRouter();
 
-  const { assistantId, threadId } = useSlugRoutes();
+  const { assistantId, threadId: currentThreadId } = useSlugRoutes();
 
   useEffect(() => {
     if (assistantId && threadsData) {
@@ -51,7 +51,10 @@ export default function Navbar() {
     <div className="flex">
       <div className="flex h-full rounded flex-col items-center bg-transparent">
         {!threadsLoading && (
-          <NewThreadBtn handleClick={onNewThreadClick} disabled={!threadId} />
+          <NewThreadBtn
+            handleClick={onNewThreadClick}
+            disabled={!currentThreadId}
+          />
         )}
         {!threadsLoading &&
           Object.values(filteredThreads).every(
@@ -77,7 +80,11 @@ export default function Navbar() {
                     <h2 className="m-3 text-gray-400">{groupName}</h2>
                     {/* @ts-ignore */}
                     {threads?.map((thread) => (
-                      <ThreadItem key={thread.id} thread={thread} />
+                      <ThreadItem
+                        key={`chat-${thread.id}`}
+                        thread={thread}
+                        currentThreadId={currentThreadId}
+                      />
                     ))}
                   </div>
                 );

--- a/ui/src/components/features/navbar/components/thread-item.tsx
+++ b/ui/src/components/features/navbar/components/thread-item.tsx
@@ -13,29 +13,32 @@ import { ChangeEvent, useEffect, useState } from "react";
 
 type TThreadItemProps = {
   thread: TThread;
+  currentThreadId: string | undefined;
 };
 
-export default function ThreadItem({ thread }: TThreadItemProps) {
+export default function ThreadItem({
+  thread,
+  currentThreadId,
+}: TThreadItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedName, setEditedname] = useState(thread.name || "New thread");
-  const [isSelected, setIsSelected] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
 
-  const {mutate: updateThread, variables: optimisticThread, isPending} = useUpdateThread(thread.id!);
+  const {
+    mutate: updateThread,
+    variables: optimisticThread,
+    isPending,
+  } = useUpdateThread(thread.id!);
   const deleteThread = useDeleteThread(thread.id!);
 
   const router = useRouter();
-  const pathname = usePathname();
   const { toast } = useToast();
   const { assistantId } = useSlugRoutes();
-
-  useEffect(() => {
-    setIsSelected(pathname.includes(thread.id!));
-  }, [pathname, thread.id]);
+  const isCurrentThread = currentThreadId && currentThreadId === thread.id;
 
   const handleItemClick = () => {
-    if (isSelected) return;
+    if (isCurrentThread) return;
     router.push(`/a/${thread.assistant_id}/c/${thread.id}`);
   };
 
@@ -73,10 +76,11 @@ export default function ThreadItem({ thread }: TThreadItemProps) {
 
   const handleEditing = () => {
     if (isEditing) return;
-    setIsEditing((prev) => !prev)
-  }
+    setIsEditing((prev) => !prev);
+  };
 
-  const iconStyles = "cursor-pointer transition-all duration-200 stroke-1 hover:stroke-2 text-slate-400";
+  const iconStyles =
+    "cursor-pointer transition-all duration-200 stroke-1 hover:stroke-2 text-slate-400";
 
   return (
     <a
@@ -85,27 +89,35 @@ export default function ThreadItem({ thread }: TThreadItemProps) {
       onMouseLeave={() => setIsHovering(false)}
       className={cn(
         isDeleting ? "fade-out" : "",
-        isEditing ? "bg-black" : "",
+        isEditing || isCurrentThread ? "bg-black" : "",
         "fade-in flex p-3 gap-2 rounded items-center cursor-pointer transition-all duration-200 hover:bg-black",
       )}
     >
       {!isEditing ? (
-        <span className="truncate">{isPending ? optimisticThread.name : thread.name}</span>
+        <span className="truncate">
+          {isPending ? optimisticThread.name : thread.name ?? "New thread"}
+        </span>
       ) : (
-          <Input
-            className="bg-transparent text-md p-0 m-0 h-full"
-            value={editedName}
-            onChange={handleUpdateName}
-            onBlur={submitUpdatedName}
-            autoFocus
-          />
+        <Input
+          className="bg-transparent text-md p-0 m-0 h-full"
+          value={editedName}
+          onChange={handleUpdateName}
+          onBlur={submitUpdatedName}
+          autoFocus
+        />
       )}
-      <div className={cn(isHovering || isEditing ? "flex ml-auto gap-2 items-center" : "hidden")}>
-          <EditIcon
-            onClick={handleEditing}
-            className={cn(iconStyles, isEditing && "stroke-2")}
-          />
-          <Trash className={iconStyles} onClick={handleDeleteThread} />
+      <div
+        className={cn(
+          isHovering || isEditing
+            ? "flex ml-auto gap-2 items-center"
+            : "hidden",
+        )}
+      >
+        <EditIcon
+          onClick={handleEditing}
+          className={cn(iconStyles, isEditing && "stroke-2")}
+        />
+        <Trash className={iconStyles} onClick={handleDeleteThread} />
       </div>
     </a>
   );


### PR DESCRIPTION
These are just small improvements to the list of chats/threads in the navbar. No new functionality was added. Improvements include: 
* highlighting of currently active chate/stream - it was hard to find which one I selected when I played with different chats;
* usage of "fallback" chat/thread name in case thread/title request failes (that's really an edge case but for me happened several times while I was playing with the code, just nice to have a fallback name when this happens).

Some reformatting changes can be seen. Not sure how it happened that we all have different prettier settings. 

To test. Just run UI and make sure an active chat is highlighted.